### PR TITLE
Add branch pattern matching

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, 'test/**', 'tnd/**']
     tags: ['*']
   pull_request:
 jobs:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation
 on:
   push:
-    branches: [main]
+    branches: [main, 'docs/**', 'tnd/**']
     tags: ['*']
   pull_request:
 jobs:


### PR DESCRIPTION
This change allows us to make branches called "test/\*\*", "docs/\*\*", or "tnd/\*\*" which will trigger tests, doc builds, or both (respectively) on every push. This makes it easier to test each commit in development without creating a PR.