### PR TITLE
Match text of README.md with docs/src/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 </tbody>
 </table>
 
-OpticSim.jl is a [Julia](https://julialang.org/) geometric optics (ray tracing) package for simulation and optimization of complex optical systems developed by the Microsoft Research Interactive Media Group and the Microsoft Hardware Architecture incubation Team (HART) group.
+OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics (ray tracing) simulation and optimization of complex optical systems developed by the Microsoft Research Interactive Media Group and the Microsoft Hardware Architecture incubation Team (HART) group.
 
 It is designed to allow optical engineers to create optical systems procedurally and then to simulate and optimize them. Unlike Zemax, Code V, or other interactive optical design systems OpticSim.jl has limited support for interactivity, primarily in the tools for visualizing optical systems.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 </tbody>
 </table>
 
-OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics (ray tracing) simulation and optimization of complex optical systems developed by the Microsoft Research Interactive Media Group and the Microsoft Hardware Architecture incubation Team (HART) group.
+OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics (ray tracing) simulation and optimization of complex optical systems developed by the Microsoft Research Interactive Media Group and the Microsoft Hardware Architecture Incubation Team (HART).
 
 It is designed to allow optical engineers to create optical systems procedurally and then to simulate and optimize them. Unlike Zemax, Code V, or other interactive optical design systems OpticSim.jl has limited support for interactivity, primarily in the tools for visualizing optical systems.
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Before you can use the software you will need to download glass files. See the d
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+provided by the bot. You will only need to do this once across all repositories using our CLA.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # OpticSim.jl
 
-OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics (ray tracing) simulation and optimization of complex optical systems developed by the Microsoft Research Interactive Media Group and the Microsoft Hardware Architecture incubation Team (HART) group.
+OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics (ray tracing) simulation and optimization of complex optical systems developed by the Microsoft Research Interactive Media Group and the Microsoft Hardware Architecture Incubation Team (HART).
 
 It is designed to allow optical engineers to create optical systems procedurally and then to simulate and optimize them. Unlike Zemax, Code V, or other interactive optical design systems OpticSim.jl has limited support for interactivity, primarily in the tools for visualizing optical systems.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,12 +16,13 @@ OpticSim.jl is optimized for use with Julia 1.5.2-1.6.0; using other versions ma
 The system will automatically download glass catalog (.agf) files from some manufacturers when the package is built for the first time. These files are in an industry standard format and can be downloaded from many optical glass manufacturers.
 
 Here are links to several publicly available glass files:
-*   [NIKON](https://www.nikon.com/products/optical-glass/assets/pdf/nikon_zemax_data.zip) (automatically downloaded)
-*   [NHG](http://hbnhg.com/down/data/nhgagp.zip) (you have to manually download)
-*   [OHARA](https://www.oharacorp.com/xls/OHARA_201130_CATALOG.zip) (automatically downloaded)
-*   [HOYA](https://hoyaoptics.com/wp-content/uploads/2019/10/HOYA20170401.zip) (automatically downloaded)
-*   [Sumita](https://www.sumita-opt.co.jp/en/download/) (automatically downloaded)
-*   [SCHOTT](https://www.schott.com/advanced_optics/english/download/index.html) (automatically downloaded)
+
+* [NIKON](https://www.nikon.com/products/optical-glass/assets/pdf/nikon_zemax_data.zip) (automatically downloaded)
+* [NHG](http://hbnhg.com/down/data/nhgagp.zip) (you have to manually download)
+* [OHARA](https://www.oharacorp.com/xls/OHARA_201130_CATALOG.zip) (automatically downloaded)
+* [HOYA](https://hoyaoptics.com/wp-content/uploads/2019/10/HOYA20170401.zip) (automatically downloaded)
+* [Sumita](https://www.sumita-opt.co.jp/en/download/) (automatically downloaded)
+* [SCHOTT](https://www.schott.com/advanced_optics/english/download/index.html) (automatically downloaded)
 
 OpticSim.jl will generate a glass database from the available files in `deps/downloads/glasscat/` and store it in the file `AGFClassCat.jl`. See [GlassCat](@ref) for a detailed description, including instructions on how to add more catalogs.
 
@@ -56,4 +57,3 @@ julia --project=[your_project] --sysimage=[path_to_sysimage]
 ```
 
 If OpticSim.jl is installed in the base project then there is no need for the `--project` flag in the above commands.
-


### PR DESCRIPTION
Besides the added consistency, this also makes the sentence easier to read.

The redundant expression "Hardware Architecture Incubation Team group" was also corrected to "Hardware Architecture Incubation Team".

Finally, a few tweaks were made to the affected files (mostly [markdownlint](https://github.com/DavidAnson/markdownlint) recommendations).

This PR is a follow-up to #45 and #51.