### PR TITLE
Add Julia 1.6, 1.7 to tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,9 @@ jobs:
           "C:\Program Files\7-Zip\7z.exe" x mesa.7z
           mklink opengl32.dll "x64\opengl32.dll"
           mklink libglapi.dll "x64\libglapi.dll"
+      - name: Install GR dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt install libxt6 libxrender1 libxext6 libgl1-mesa-glx libqt5widgets5
       - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.5']
+        version: ['1.5', '1.6', 'nightly']
         os: [ubuntu-18.04, windows-latest]
         arch: [x64]
         include:

--- a/test/testsets/JuliaLang.jl
+++ b/test/testsets/JuliaLang.jl
@@ -16,7 +16,7 @@ and pop it from the set
     # for some weird reason the unbound args check seems to fail for some (seemingly random) methods with Vararg arguments
     methods_to_ignore = Dict(
         OpticSim => VERSION >= v"1.6.0-DEV" ? [
-            (OpticSim.LensAssembly, Tuple{Vararg{Union{CSGTree{T},LensAssembly{T},Surface{T}},N} where N} where {T<:Real}),
+            (OpticSim.LensAssembly, Tuple{Vararg{Union{CSGTree{T},LensAssembly{T},OpticSim.Surface{T}},N} where N} where {T<:Real}),
             (OpticSim.RayListSource, Tuple{Vararg{OpticalRay{T,3},N} where N} where {T<:Real}),
             (OpticSim.OpticalSourceGroup, Tuple{Vararg{OpticalRayGenerator{T},N} where N} where {T<:Real}),
             (OpticSim.PixelSource, Tuple{Vararg{P,N} where N} where {P<:OpticalRayGenerator{T}} where {T<:Real}),


### PR DESCRIPTION
* add Julia 1.6 and nightly (1.7) tests

* fix JuliaLang bug (OpticSim.Surface <-> Plots.Surface namepsace clash)

* Install GR dependencies (Linux)

https://gr-framework.org/python.html#installation