### PR TITLE
TaskFailedException  Fixes #50

### DIFF
--- a/src/Geometry/CSG/CSG.jl
+++ b/src/Geometry/CSG/CSG.jl
@@ -337,7 +337,9 @@ function empty!(a::TrianglePool{T}) where {T<:Real}
     end
 end
 
-const threadedtrianglepool = [Dict{DataType,TrianglePool}([Float64 => TrianglePool{Float64}()]) for _ in 1:Threads.nthreads()]
+# Allocate a zero length array which will be filled with Threads.nthreads() entries by the __init__ method for OpticSim module. Have to do this in the __init__ method because this captures the load time environment. const values are evaluated at precompile time and the number of threads in these two environments can be different.
+const threadedtrianglepool = Vector{Dict{DataType,TrianglePool}}()
+#const threadedtrianglepool = [Dict{DataType,TrianglePool}([Float64 => TrianglePool{Float64}()]) for _ in 1:Threads.nthreads()]
 
 function newintrianglepool!(::Type{T} = Float64, tid::Int = Threads.threadid())::Vector{Triangle{T}} where {T<:Real}
     if T ∉ keys(threadedtrianglepool[tid])

--- a/src/Geometry/CSG/Interval.jl
+++ b/src/Geometry/CSG/Interval.jl
@@ -120,7 +120,9 @@ function empty!(a::IntervalPool{T}) where {T<:Real}
     end
 end
 
-const threadedintervalpool = [Dict{DataType,IntervalPool}([Float64 => IntervalPool{Float64}()]) for _ in 1:Threads.nthreads()]
+# Allocate a zero length array which will be filled with Threads.nthreads() entries by the __init__ method for OpticSim module. Have to do this in the __init__ method because this captures the load time environment. const values are evaluated at precompile time and the number of threads in these two environments can be different.
+const threadedintervalpool = Vector{Dict{DataType,IntervalPool}}()
+#const threadedintervalpool = [Dict{DataType,IntervalPool}([Float64 => IntervalPool{Float64}()]) for _ in 1:Threads.nthreads()]
 
 function newinintervalpool!(::Type{T} = Float64, tid::Int = Threads.threadid())::Vector{Interval{T}} where {T<:Real}
     if T ∉ keys(threadedintervalpool[tid])

--- a/src/OpticSim.jl
+++ b/src/OpticSim.jl
@@ -44,6 +44,15 @@ include("Visualization/Visualization.jl")
 include("Examples/Examples.jl")
 include("Optimization/Optimization.jl")
 
+#initialize these caches here so they will get the correct number of threads from the load time environment, rather than the precompile environment. The latter happens if the initialization happens in the const definition. If the precompile and load environments have different numbers of threads this will cause an error.
+function __init__()
+    for _ in 1:Threads.nthreads()
+        push!(threadedtrianglepool,Dict{DataType,TrianglePool}((Float64 => TrianglePool{Float64}())))
+        push!(threadedintervalpool,Dict{DataType,IntervalPool}((Float64 => IntervalPool{Float64}())))
+    end
+end
+
+
 ################################################
 
 # This can be used to track NaN, particularly in ForwardDiff gradients, causing problems


### PR DESCRIPTION
# Pull Request Template

## Description

threadedintervalpool and threadedtrianglepool were initialized in the const definitions. This gave them the size of the precompile value of Threads.nthreads(). If the load time value of Threads.nthreads() was not the same this could cause a crash

Fixes # 50

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

verified interactively that the size of threadedintervalpool and threadtrianglepool both match the load time value of Threads.nthreads() rather than the precompile value.
**Test Configuration(s)**:

* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
