### PR TITLE
Fix glasscat documentation

### DIFF
--- a/docs/src/glasscat.md
+++ b/docs/src/glasscat.md
@@ -68,7 +68,7 @@ OpticSim.GlassCat.modelglass
 
 ```@docs
 OpticSim.GlassCat.glasscatalogs
-OpticSim.GlassCat.glasses
+OpticSim.GlassCat.glassnames
 OpticSim.GlassCat.info
 OpticSim.GlassCat.findglass
 OpticSim.GlassCat.isair

--- a/src/GlassCat/Air.jl
+++ b/src/GlassCat/Air.jl
@@ -3,6 +3,11 @@ Base.show(io::IO, ::AirType) = print(io, "Air")
 glassid(::AirType) = GlassID(AIR, 0)
 glassname(::AirType) = "GlassCat.Air"
 
+"""
+    isair(a) -> Bool
+
+Tests if a is Air.
+"""
 isair(::AirType) = true
 isair(::AbstractGlass) = false
 isair(a::GlassID) = a.type === AIR


### PR DESCRIPTION
1. update docs to reflect renaming of GlassCat.glasses ->
   GlassCat.glassnames
2. restore docstring for isair()

fixes #81