### PR TITLE
Fix relative paths in new emitter docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ using OpticSim
 makedocs(
     sitename = "OpticSim.jl",
     format = Documenter.HTML(
-        prettyurls = get(ENV, "CI", nothing) == "true",
+        # prettyurls = get(ENV, "CI", nothing) == "true",
         assets = [asset("assets/logo.svg", class = :ico, islocal = true)],
     ),
     modules = [OpticSim],

--- a/docs/src/emitters_new.md
+++ b/docs/src/emitters_new.md
@@ -48,8 +48,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_rect_grid.png">
-    <img width="250" src="assets/emitters_example_rect_grid.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_rect_grid.png">
+    <img width="250" src="../assets/emitters_example_rect_grid.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -69,8 +69,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_uniform_cone.png">
-    <img width="250" src="assets/emitters_example_uniform_cone.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_uniform_cone.png">
+    <img width="250" src="../assets/emitters_example_uniform_cone.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -90,8 +90,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_hexapolar_cone.png">
-    <img width="250" src="assets/emitters_example_hexapolar_cone.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_hexapolar_cone.png">
+    <img width="250" src="../assets/emitters_example_hexapolar_cone.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -113,8 +113,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_origin_rectgrid.png">
-    <img width="250" src="assets/emitters_example_origin_rectgrid.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_origin_rectgrid.png">
+    <img width="250" src="../assets/emitters_example_origin_rectgrid.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -134,8 +134,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_origin_hexapolar.png">
-    <img width="250" src="assets/emitters_example_origin_hexapolar.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_origin_hexapolar.png">
+    <img width="250" src="../assets/emitters_example_origin_hexapolar.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -163,8 +163,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_angular1.png">
-    <img width="250" src="assets/emitters_example_angular1.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_angular1.png">
+    <img width="250" src="../assets/emitters_example_angular1.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -188,8 +188,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_angular2.png">
-    <img width="250" src="assets/emitters_example_angular2.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_angular2.png">
+    <img width="250" src="../assets/emitters_example_angular2.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">
@@ -243,8 +243,8 @@ nothing #hide
 ```@raw html
 <table><tr>
 <td>
-<a target="_blank" href="assets/emitters_example_composite_display.png">
-    <img width="500" src="assets/emitters_example_composite_display.png" style="max-width:100%;">
+<a target="_blank" href="../assets/emitters_example_composite_display.png">
+    <img width="500" src="../assets/emitters_example_composite_display.png" style="max-width:100%;">
 </a>
 </td>
 <td valign="middle">


### PR DESCRIPTION
I think that the confusion came from me enabling the `prettyurls` argument in `makedocs` in `docs/make.jl`.

Enabling this option probably did more harm than good. It made locally built docs easier to navigate, but it meant that the local and remote doc builds differed in directory structure, which is confusing and difficult to work with.

We need to go back one time because the html paths are relative to `docs/build/emitters_new/index.html` rather than
`docs/build/emitters_new.html`, which is what the `prettyurl` doc build would have you believe. Confusingly, julia code is executed from docs/build, which means that `Vis.save` shouldn't go back in its relative path!

~~Will upgrade this from a draft PR once the preview confirms the fix.~~

[Fixed!](https://microsoft.github.io/OpticSim.jl/previews/PR131/emitters_new/)