### PR TITLE
Removing functions zero3 and one3.

### DIFF
--- a/docs/src/basic_types.md
+++ b/docs/src/basic_types.md
@@ -15,8 +15,6 @@ OpticSim.Geometry.Vec3
 OpticSim.Geometry.unitX3
 OpticSim.Geometry.unitY3
 OpticSim.Geometry.unitZ3
-OpticSim.Geometry.zero3
-OpticSim.Geometry.one3
 ```
 
 ## Vec4
@@ -29,8 +27,6 @@ OpticSim.Geometry.unitX4
 OpticSim.Geometry.unitY4
 OpticSim.Geometry.unitZ4
 OpticSim.Geometry.unitW4
-OpticSim.Geometry.zero4
-OpticSim.Geometry.one4
 ```
 
 ## Transform

--- a/src/Geometry/Transform.jl
+++ b/src/Geometry/Transform.jl
@@ -38,16 +38,8 @@ unitY3(::Type{T} = Float64) where {T<:Real} = Vec3{T}(zero(T), one(T), zero(T))
 returns the unit vector `[0, 0, 1]`
 """
 unitZ3(::Type{T} = Float64) where {T<:Real} = Vec3{T}(zero(T), zero(T), one(T))
-"""
-returns the unit vector `[0, 0, 0]`
-"""
-zero3(::Type{T} = Float64) where {T<:Real} = zeros(Vec3{T})
-"""
-returns the unit vector `[1, 1, 1]`
-"""
-one3(::Type{T} = Float64) where {T<:Real} = Vec3{T}(one(T), one(T), one(T))
 
-export unitX3, unitY3, unitZ3, zero3, one3
+export unitX3, unitY3, unitZ3
 
 #endregion Vec3
 
@@ -105,16 +97,8 @@ unitZ4(::Type{T} = Float64) where {T<:Real} = Vec4{T}(zero(T), zero(T), one(T), 
 returns the unit vector `[0, 0, 0, 1]`
 """
 unitW4(::Type{T} = Float64) where {T<:Real} = Vec4{T}(zero(T), zero(T), zero(T), one(T))
-"""
-returns the unit vector `[0, 0, 0, 0]`
-"""
-zero4(::Type{T} = Float64) where {T<:Real} = zeros(Vec4{T})
-"""
-returns the unit vector `[1, 1, 1, 1]`
-"""
-one4(::Type{T} = Float64) where {T<:Real} = Vec4{T}(one(T), one(T), one(T), one(T))
 
-export unitX4, unitY4, unitZ4, unitW4, zero4, one4
+export unitX4, unitY4, unitZ4, unitW4
 #endregion Vec4
 
 
@@ -163,6 +147,7 @@ Transform(rotation::AbstractArray{S,2}, translation::AbstractArray{S,1})
 Transform{T} = SMatrix{4,4,T,16}
 export Transform
 
+lastrow(::Type{T}) where{T<:Real} = SMatrix{1,4,T}(zero(T),zero(T),zero(T),one(T)) 
 
 # for compatability ith the "old" RigidBodyTransform
 """
@@ -193,14 +178,10 @@ end
 
 Costruct a transform from the input columns.     
 """
-function Transform(colx::Vec3{T}, coly::Vec3{T}, colz::Vec3{T}, colw::Vec3{T} = zero3(T)) where {T<:Real}
-    return Transform{T}(
-        colx[1], colx[2], colx[3], zero(T), 
-        coly[1], coly[2], coly[3], zero(T), 
-        colz[1], colz[2], colz[3], zero(T), 
-        colw[1], colw[2], colw[3], one(T)
-    )
+function Transform(colx::Vec3{T}, coly::Vec3{T}, colz::Vec3{T}, colw::Vec3{T} = zero(Vec3{T})) where {T<:Real}
+    return vcat(hcat(colx,coly,colz,colw),lastrow(T))
 end
+
 
 """
     Transform(colx::Vec3{T}, coly::Vec3{T},colz::Vec3{T}, colw::Vec3{T}, ::Type{T} = Float64) where {T<:Real}
@@ -208,12 +189,7 @@ end
 Costruct a transform from the input columns.     
 """
 function Transform(colx::Vec4{T}, coly::Vec4{T}, colz::Vec4{T}, colw::Vec4{T}) where {T<:Real}
-    return Transform{T}(
-        colx[1], colx[2], colx[3], colx[4], 
-        coly[1], coly[2], coly[3], coly[4], 
-        colz[1], colz[2], colz[3], colz[4], 
-        colw[1], colw[2], colw[3], colw[4]
-    )
+    return hcat(colx,coly,colz,colw)
 end
 
 """
@@ -258,7 +234,6 @@ function Transform(rotation::AbstractArray{T,2}, translation::AbstractArray{T,1}
         rotation[1,3], rotation[2,3], rotation[3,3], zero(T), 
         translation[1], translation[2], translation[3], one(T))
 end
-
 
 """
     rotationX(angle::T) where {T<:Real} -> Transform
@@ -333,7 +308,7 @@ function rotation(t::Transform{T}) where {T<:Real}
         t[1, 1], t[2, 1], t[3, 1], 
         t[1, 2], t[2, 2], t[3, 2],
         t[1, 3], t[2, 3], t[3, 3])
-    return Transform(rot, zero3(T))
+    return Transform(rot, zero(Vec3{T}))
 end
 
 """

--- a/src/Geometry/Transform.jl
+++ b/src/Geometry/Transform.jl
@@ -147,8 +147,6 @@ Transform(rotation::AbstractArray{S,2}, translation::AbstractArray{S,1})
 Transform{T} = SMatrix{4,4,T,16}
 export Transform
 
-lastrow(::Type{T}) where{T<:Real} = SMatrix{1,4,T}(zero(T),zero(T),zero(T),one(T)) 
-
 # for compatability ith the "old" RigidBodyTransform
 """
 identitytransform([S::Type]) -> Transform{S}
@@ -179,7 +177,7 @@ end
 Costruct a transform from the input columns.     
 """
 function Transform(colx::Vec3{T}, coly::Vec3{T}, colz::Vec3{T}, colw::Vec3{T} = zero(Vec3{T})) where {T<:Real}
-    return vcat(hcat(colx,coly,colz,colw),lastrow(T))
+    return vcat(hcat(colx,coly,colz,colw),SMatrix{1,4,T}(zero(T),zero(T),zero(T),one(T)) )
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,7 @@ alltestsets = [
     "Visualization",
     "Allocations",
     "GlassCat",
+    "Transform"
 ]
 
 runtestsets = ALL_TESTS ? alltestsets : intersect(alltestsets, ARGS)

--- a/test/testsets/Transform.jl
+++ b/test/testsets/Transform.jl
@@ -1,0 +1,24 @@
+# MIT license
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# See LICENSE in the project root for full license information.
+
+@testset "Transform" begin
+    A = [
+        1 2 3 4;
+        4 5 6 7;
+        8 9 10 11;
+        12 13 14 15
+    ]
+    x,y,z,w = Vec4.([A[:,i] for i in 1:4])
+    @test Geometry.Transform(x,y,z,w) == A
+
+    B = [
+        1 2 3 4;
+        4 5 6 7;
+        8 9 10 11;
+        0 0 0 1
+    ]
+    x,y,z,w = Vec3.([B[1:3,i] for i in 1:4])
+    @test B == Geometry.Transform(x,y,z,w)
+
+end # testset Allocations


### PR DESCRIPTION
## Description

Removed zero3,one3,zero4,one4. Julia already provides the zero and ones functions that have equivalent functionality.

Simplified some of the Transform functions.

Fixes # (157)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

wrote tests to verify that the new Transform functions generated the correct matrices and added these tests to our unit test set.

**Test Configuration(s)**:

* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
