### PR TITLE
pointemitter and collimatedemittor not defined

### DIFF
--- a/src/Optical/Emitters/Emitters.jl
+++ b/src/Optical/Emitters/Emitters.jl
@@ -11,6 +11,7 @@ module Emitters
 export generate, visual_size, apply
 export right, up, forward
 export Spectrum, Directions, Origins, AngularPower, Sources
+export pointemitter, collimatedemitter
 
 using ...OpticSim, ..Geometry
 using LinearAlgebra


### PR DESCRIPTION
# Pull Request Template

## Description

pointemitter and collimatedemitter were added as convenience functions to the Emitters module but they are not exported. This code change exports the two functions.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

ran unit tests

**Test Configuration(s)**:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
