### PR TITLE
Replace lingering generateray() calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "OpticSim"
 uuid = "24114763-4efb-45e7-af0e-cde916beb153"
 authors = ["Brian Guenter", "Charlie Hewitt", "Ran Gal", "Alfred Wong"]
 repository = "https://github.com/microsoft/OpticSim.jl"
-version = "0.5.0-DEV"
+version = "0.5.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/Optical/OpticalSystem.jl
+++ b/src/Optical/OpticalSystem.jl
@@ -426,14 +426,14 @@ function traceMT(system::CSGOpticalSystem{T,S}, raygenerator::OpticalRayGenerato
                         print("\rTraced: ~ $t / $(length(sources))        Elapsed: $(dif)s        Left: $(left)s           ")
                     end
                 end
-                trace(system, generateray(sources, k), test = test)
+                trace(system, sources[k]; test)
             end
         else
             for k in f:l
                 if k % update_timesteps == 0
                     Threads.atomic_add!(total_traced, update_timesteps)
                 end
-                trace(system, generateray(sources, k), test = test)
+                trace(system, sources[k]; test)
             end
         end
     end
@@ -533,7 +533,7 @@ function tracehitsMT(system::CSGOpticalSystem{T}, raygenerator::OpticalRayGenera
                         print("\rTraced: ~ $t / $(length(sources))        Elapsed: $(dif)s        Left: $(left)s           ")
                     end
                 end
-                lt = trace(system, generateray(sources, k), test = test)
+                lt = trace(system, sources[k]; test)
                 if lt !== nothing
                     push!(results[i], lt)
                 end
@@ -543,7 +543,7 @@ function tracehitsMT(system::CSGOpticalSystem{T}, raygenerator::OpticalRayGenera
                 if k % update_timesteps == 0
                     Threads.atomic_add!(total_traced, update_timesteps)
                 end
-                lt = trace(system, generateray(sources, k), test = test)
+                lt = trace(system, sources[k]; test)
                 if lt !== nothing
                     push!(results[i], lt)
                 end


### PR DESCRIPTION
There were some lingering calls to `generateray`, which is from the old Emitters API, in the `trace` function. It seems that the same functionality can be achieved with the new API by doing the following replacement:

`generateray(sources, k)` -> `sources[k]`

@galran could you confirm?

On a side note, this means that none of our multithreaded trace functions are being tested (confirmed here https://codecov.io/gh/microsoft/OpticSim.jl/src/main/src/Optical/OpticalSystem.jl#L376). @BrianGun is this because it was particularly difficult to test multithreaded code, or did we just skip it?