### PR TITLE
Replace leaf/transform with csgtransform

### DIFF
--- a/docs/src/csg.md
+++ b/docs/src/csg.md
@@ -12,7 +12,7 @@ The code for this in our system would look this this:
 ```@example
 using OpticSim # hide
 cyl = Cylinder(0.7)
-cyl_cross = cyl ∪ leaf(cyl, Geometry.rotationd(90, 0, 0)) ∪ leaf(cyl, Geometry.rotationd(0, 90, 0))
+cyl_cross = cyl ∪ csgtransform(cyl, Geometry.rotationd(90, 0, 0)) ∪ csgtransform(cyl, Geometry.rotationd(0, 90, 0))
 
 cube = Cuboid(1.0, 1.0, 1.0)
 sph = Sphere(1.3)

--- a/samples/notebooks/BasicCSG.jl
+++ b/samples/notebooks/BasicCSG.jl
@@ -101,12 +101,12 @@ begin
 	csg1_surf1 = AcceleratedParametricSurface(beziersurface(), 25);
 	
 	# two transformed copies of the canonic bezier surface
-	csg1_surf2 = leaf(csg1_surf1, OpticSim.translation(-0.5, -0.5, 0.0))
-	csg1_surf3 = leaf(csg1_surf1, Transform{Float64}(0.0, Float64(π), 0.0, 0.5, -0.5, 0.0))
+	csg1_surf2 = csgtransform(csg1_surf1, OpticSim.translation(-0.5, -0.5, 0.0))
+	csg1_surf3 = csgtransform(csg1_surf1, Transform{Float64}(0.0, Float64(π), 0.0, 0.5, -0.5, 0.0))
 	
 	# transformed cilinder
-	csg1_surf4_1 = leaf(Cylinder(0.3, 1.0), OpticSim.translation(0.0, 0.0, 0.0))
-	csg1_surf4 = leaf(csg1_surf4_1, OpticSim.rotation(deg2rad(cyl_rot_x), deg2rad(cyl_rot_y), deg2rad(cyl_rot_z)))
+	csg1_surf4_1 = csgtransform(Cylinder(0.3, 1.0), OpticSim.translation(0.0, 0.0, 0.0))
+	csg1_surf4 = csgtransform(csg1_surf4_1, OpticSim.rotation(deg2rad(cyl_rot_x), deg2rad(cyl_rot_y), deg2rad(cyl_rot_z)))
 	
 	# intersection result	
 	csg1_surf5 = (csg1_surf2 ∩ csg1_surf4 ∩ csg1_surf3)()

--- a/samples/notebooks/Samples.jl
+++ b/samples/notebooks/Samples.jl
@@ -145,10 +145,10 @@ begin
 	# glass entrance lens on telescope
 	topsurf = Plane(OpticSim.SVector(0.0, 0.0, 1.0), OpticSim.SVector(0.0, 0.0, 0.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air), vishalfsizeu = 12.00075, vishalfsizev = 12.00075)
 	botsurf = AcceleratedParametricSurface(ZernikeSurface(12.00075, radius = -1.14659768e+4, aspherics = [(4, 3.68090959e-7), (6, 2.73643352e-11), (8, 3.20036892e-14)]), 17, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air))
-	coverlens = Cylinder(12.00075, 1.4) ∩ topsurf ∩ leaf(botsurf, Transform(OpticSim.rotmatd(0, 180, 0), OpticSim.SVector(0.0, 0.0, -0.65)))
+	coverlens = Cylinder(12.00075, 1.4) ∩ topsurf ∩ csgtransform(botsurf, Transform(OpticSim.rotmatd(0, 180, 0), OpticSim.SVector(0.0, 0.0, -0.65)))
 	# big mirror with a hole in it
 	bigmirror = ConicLens(OpticSim.GlassCat.SCHOTT.N_BK7, -72.65, -95.2773500000134, 0.077235, Inf, 0.0, 0.2, 12.18263, frontsurfacereflectance = 1.0)
-	bigmirror = bigmirror - leaf(Cylinder(4.0, 0.3, interface = opaqueinterface()), OpticSim.translation(0.0, 0.0, -72.75))
+	bigmirror = bigmirror - csgtransform(Cylinder(4.0, 0.3, interface = opaqueinterface()), OpticSim.translation(0.0, 0.0, -72.75))
 	# small mirror supported on a spider
 	smallmirror = SphericalLens(OpticSim.GlassCat.SCHOTT.N_BK7, -40.65, Inf, -49.6845, 1.13365, 4.3223859, backsurfacereflectance = 1.0)
 	obscuration1 = OpticSim.Circle(4.5, OpticSim.SVector(0.0, 0.0, 1.0), OpticSim.SVector(0.0, 0.0, -40.649), interface = opaqueinterface())
@@ -176,9 +176,9 @@ end
 begin
 	drawing	# notebook only - create dependency on drawing backend - comment if running in REPL
 
-	topsurface = leaf(AcceleratedParametricSurface(QTypeSurface(9.0, radius = -25.0, conic = 0.3, αcoeffs = [(1, 0, 0.3), (1, 1, 1.0)], βcoeffs = [(1, 0, -0.1), (2, 0, 0.4), (3, 0, -0.6)], normradius = 9.5), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), OpticSim.translation(0.0, 0.0, 5.0))
-	botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-	barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+	topsurface = csgtransform(AcceleratedParametricSurface(QTypeSurface(9.0, radius = -25.0, conic = 0.3, αcoeffs = [(1, 0, 0.3), (1, 1, 1.0)], βcoeffs = [(1, 0, -0.1), (2, 0, 0.4), (3, 0, -0.6)], normradius = 9.5), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), OpticSim.translation(0.0, 0.0, 5.0))
+	botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+	barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
 	lens = (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 	sys = CSGOpticalSystem(LensAssembly(lens), Rectangle(15.0, 15.0, [0.0, 0.0, 1.0], [0.0, 0.0, -67.8], interface = opaqueinterface()))
 	Vis.drawtracerays(sys, test = true, trackallrays = true)	

--- a/src/Examples/docs_examples.jl
+++ b/src/Examples/docs_examples.jl
@@ -3,7 +3,8 @@
 # See LICENSE in the project root for full license information.
 
 # Group examples that are used in the docs (examples.md)
-export draw_cooketriplet, draw_schmidtcassegraintelescope, draw_lensconstruction, draw_zoomlenses, draw_HOEfocus, draw_HOEcollimate, draw_multiHOE, draw_stackedbeamsplitters
+export draw_cooketriplet, draw_schmidtcassegraintelescope, draw_lensconstruction, draw_zoomlenses, draw_HOEfocus,
+    draw_HOEcollimate, draw_multiHOE, draw_stackedbeamsplitters
 
 function draw_cooketriplet(filename::Union{Nothing,AbstractString} = nothing)
     g1, g2 = SCHOTT.N_SK16, SCHOTT.N_SF2
@@ -225,22 +226,28 @@ function draw_stackedbeamsplitters(filenames::Vector{<:Union{Nothing,AbstractStr
 
     for (interfacemode, filename) in zip(interfacemodes, filenames)
         interface = FresnelInterface{Float64}(SCHOTT.N_BK7, Air; reflectance=0.5, transmission=0.5, interfacemode)
-        bs_1 = leaf(
-            leaf(
+        bs_1 = OpticSim.transform(
+            OpticSim.transform(
                 Cuboid(10.0, 20.0, 2.0; interface),
-                rotationX(π/4)),
-            translation(0.0, 0.0, -30.0-2*sqrt(2)))
-        l1 = leaf(
+                rotationX(π/4)
+                ),
+            translation(0.0, 0.0, -30.0-2*sqrt(2))
+        )
+        l1 = OpticSim.transform(
             SphericalLens(SCHOTT.N_BK7, -70.0, 30.0, Inf, 5.0, 10.0),
-            translation(0.0, -1.34, 0.0))
-        bs_2 = leaf(
-            leaf(
+            translation(0.0, -1.34, 0.0)
+        )
+        bs_2 = OpticSim.transform(
+            OpticSim.transform(
                 Cuboid(10.0, 20.0, 2.0; interface),
-                rotationX(π/4)),
-            translation(0.0, 40.0, -30.0+2*sqrt(2)))
-        l2 = leaf(
+                rotationX(π/4)
+            ),
+            translation(0.0, 40.0, -30.0+2*sqrt(2))
+        )
+        l2 = OpticSim.transform(
             SphericalLens(SCHOTT.N_BK7, -70.0, 30.0, Inf, 5.0, 10.0),
-            translation(0.0, 40.0, 0.0))
+            translation(0.0, 40.0, 0.0)
+        )
         la = LensAssembly(bs_1(), l1(), bs_2(), l2())
         detector = Rectangle(20.0, 40.0, SVector(0.0, 0.0, 1.0), SVector(0.0, 20.0, -130.0); interface = opaqueinterface())
         sys = CSGOpticalSystem(la, detector)

--- a/src/Examples/docs_examples.jl
+++ b/src/Examples/docs_examples.jl
@@ -77,13 +77,13 @@ function draw_schmidtcassegraintelescope(filename::Union{Nothing,AbstractString}
         aspherics = [(4, 3.68090959e-7), (6, 2.73643352e-11), (8, 3.20036892e-14)]),
         17,
         interface = FresnelInterface{Float64}(SCHOTT.N_BK7, Air))
-    coverlens = Cylinder(12.00075, 1.4) ∩ topsurf ∩ leaf(botsurf, Transform(rotmatd(0, 180, 0), Vec3(0.0, 0.0, -0.65)))
+    coverlens = Cylinder(12.00075, 1.4) ∩ topsurf ∩ csgtransform(botsurf, Transform(rotmatd(0, 180, 0), Vec3(0.0, 0.0, -0.65)))
 
     # big mirror with a hole in it
     frontsurfacereflectance = 1.0
     bigmirror = (
         ConicLens(SCHOTT.N_BK7, -72.65, -95.2773500000134, 0.077235, Inf, 0.0, 0.2, 12.18263; frontsurfacereflectance) -
-        leaf(Cylinder(4.0, 0.3, interface = opaqueinterface()), translation(0.0, 0.0, -72.75))
+        csgtransform(Cylinder(4.0, 0.3, interface = opaqueinterface()), translation(0.0, 0.0, -72.75))
     )
 
     # small mirror supported on a spider
@@ -111,7 +111,7 @@ function draw_schmidtcassegraintelescope(filename::Union{Nothing,AbstractString}
 end
 
 function draw_lensconstruction(filename::Union{Nothing,AbstractString} = nothing)
-    topsurface = leaf(
+    topsurface = csgtransform(
         AcceleratedParametricSurface(
             QTypeSurface(
                 9.0,
@@ -226,25 +226,25 @@ function draw_stackedbeamsplitters(filenames::Vector{<:Union{Nothing,AbstractStr
 
     for (interfacemode, filename) in zip(interfacemodes, filenames)
         interface = FresnelInterface{Float64}(SCHOTT.N_BK7, Air; reflectance=0.5, transmission=0.5, interfacemode)
-        bs_1 = OpticSim.transform(
-            OpticSim.transform(
+        bs_1 = csgtransform(
+            csgtransform(
                 Cuboid(10.0, 20.0, 2.0; interface),
                 rotationX(π/4)
                 ),
             translation(0.0, 0.0, -30.0-2*sqrt(2))
         )
-        l1 = OpticSim.transform(
+        l1 = csgtransform(
             SphericalLens(SCHOTT.N_BK7, -70.0, 30.0, Inf, 5.0, 10.0),
             translation(0.0, -1.34, 0.0)
         )
-        bs_2 = OpticSim.transform(
-            OpticSim.transform(
+        bs_2 = csgtransform(
+            csgtransform(
                 Cuboid(10.0, 20.0, 2.0; interface),
                 rotationX(π/4)
             ),
             translation(0.0, 40.0, -30.0+2*sqrt(2))
         )
-        l2 = OpticSim.transform(
+        l2 = csgtransform(
             SphericalLens(SCHOTT.N_BK7, -70.0, 30.0, Inf, 5.0, 10.0),
             translation(0.0, 40.0, 0.0)
         )

--- a/src/Examples/other_examples.jl
+++ b/src/Examples/other_examples.jl
@@ -316,7 +316,7 @@ function eyetrackHOE(nrays = 5000, det = false, showhead = true, zeroorder = fal
 
     mint = MultiHologramInterface(interfaces...)
     obj = MultiHologramSurface(rect, mint)
-    cornea = leaf(Sphere(cornea_rad, interface = FresnelInterface{Float64}(EYE.CORNEA, Air, reflectance = 1.0, transmission = 0.0)), translation(0.0, er + cornea_rad, 0.0))()
+    cornea = csgtransform(Sphere(cornea_rad, interface = FresnelInterface{Float64}(EYE.CORNEA, Air, reflectance = 1.0, transmission = 0.0)), translation(0.0, er + cornea_rad, 0.0))()
 
     # cam settings
     fnum = 2.0
@@ -337,7 +337,7 @@ function eyetrackHOE(nrays = 5000, det = false, showhead = true, zeroorder = fal
     cambarrel = (
         barrelbot ∩
         barreltop ∩
-        leaf(Cylinder(camrad, barrellength, interface = opaqueinterface(Float64)), Transform(barrelrot, barrelloc))
+        csgtransform(Cylinder(camrad, barrellength, interface = opaqueinterface(Float64)), Transform(barrelrot, barrelloc))
     )()
     camdet = Circle(sensorrad, camdir_norm, camloc - barrellength * camdir_norm, interface = opaqueinterface(Float64))
 
@@ -364,10 +364,10 @@ function eyetrackHOE(nrays = 5000, det = false, showhead = true, zeroorder = fal
         Vis.drawtracerays(sys; raygenerator = source, trackallrays = true, kwargs...)
         # for θ in 0:(π / 6):(2π)
         #     ledloc = SVector(20 * cos(θ) + offset[1], 0 + offset[2], 15 * sin(θ) + offset[3])
-        #     Vis.draw!(leaf(Sphere(1.0), translation(ledloc...)), color = :red)
+        #     Vis.draw!(csgtransform(Sphere(1.0), translation(ledloc...)), color = :red)
         # end
         for d in dirs
-            # Vis.draw!(leaf(Sphere(1.0), translation((corneavertex - 10 * d)...)), color = :red)
+            # Vis.draw!(csgtransform(Sphere(1.0), translation((corneavertex - 10 * d)...)), color = :red)
             Vis.draw!((corneavertex - 50 * d, corneavertex), color = :red)
         end
         if showhead

--- a/src/Geometry/CSG/CSG.jl
+++ b/src/Geometry/CSG/CSG.jl
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # See LICENSE in the project root for full license information.
 
-export CSGTree, CSGGenerator, leaf
+export CSGTree, CSGGenerator, leaf, transform
 
 """Abstract type representing any evaluated CSG structure."""
 abstract type CSGTree{T} <: Primitive{T} end

--- a/src/Optical/Eye.jl
+++ b/src/Optical/Eye.jl
@@ -22,18 +22,18 @@ function ModelEye(assembly::LensAssembly{T}; nsamples::Int = 17, pupil_radius::T
 
     anterior_chamber_front = AcceleratedParametricSurface(ZernikeSurface(6.0, radius = -6.7, conic = -0.3), nsamples, interface = FresnelInterface{T}(OpticSim.GlassCat.EYE.AQUEOUS, OpticSim.GlassCat.EYE.CORNEA))
     anterior_chamber_rear = Plane(SVector{3,T}(0, 0, -1), SVector(0.0, 0.0, -3.2), vishalfsizeu = 6.0, vishalfsizev = 6.0, interface = FresnelInterface{T}(OpticSim.GlassCat.EYE.AQUEOUS, OpticSim.GlassCat.EYE.VITREOUS))
-    anterior_chamber = leaf(anterior_chamber_front ∩ anterior_chamber_rear, translation(0.0, 0.0, -0.52))(transform)
+    anterior_chamber = csgtransform(anterior_chamber_front ∩ anterior_chamber_rear, translation(0.0, 0.0, -0.52))(transform)
 
     pupil = Annulus(pupil_radius, 5.9, rotate(transform, SVector{3,T}(0, 0, 1)), transform * SVector{3,T}(0.0, 0.0, -3.62))
 
     lens_front = AcceleratedParametricSurface(ZernikeSurface(5.1, radius = -10.0), nsamples, interface = FresnelInterface{T}(OpticSim.GlassCat.EYE.LENS, OpticSim.GlassCat.EYE.VITREOUS))
     lens_rear = AcceleratedParametricSurface(ZernikeSurface(5.1, radius = 6.0, conic = -3.25), nsamples, interface = FresnelInterface{T}(OpticSim.GlassCat.EYE.LENS, OpticSim.GlassCat.EYE.VITREOUS))
     lens_barrel = Cylinder(5.0, 5.0, interface = FresnelInterface{T}(OpticSim.GlassCat.EYE.LENS, OpticSim.GlassCat.EYE.VITREOUS))
-    lens_csg = (lens_front - leaf(lens_rear, translation(0.0, 0.0, -3.7))) ∩ leaf(lens_barrel, translation(0.0, 0.0, -2.0))
-    lens = leaf(lens_csg, translation(0.0, 0.0, -3.72))(transform)
+    lens_csg = (lens_front - csgtransform(lens_rear, translation(0.0, 0.0, -3.7))) ∩ csgtransform(lens_barrel, translation(0.0, 0.0, -2.0))
+    lens = csgtransform(lens_csg, translation(0.0, 0.0, -3.72))(transform)
 
     vitreous_chamber_csg = (
-        leaf(
+        csgtransform(
             Sphere(11.0, interface = FresnelInterface{T}(EYE.VITREOUS, Air, reflectance = 0.0, transmission = 0.0)),
             translation(0.0, 0.0, -13.138998863513297)
         ) ∩

--- a/test/TestData/TestData.jl
+++ b/test/TestData/TestData.jl
@@ -158,51 +158,51 @@ chebyshevsurface2() = ChebyshevSurface(2.0, 2.0, [(1, 1, 0.1), (0, 2, 0.3), (4, 
 ### LENSES
 
 function zernikelens()
-    topsurface = leaf(AcceleratedParametricSurface(ZernikeSurface(9.5, zcoeff = [(1, 0.0), (4, -1.0), (7, 0.5)]), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(ZernikeSurface(9.5, zcoeff = [(1, 0.0), (4, -1.0), (7, 0.5)]), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 
 function asphericlens()
-    topsurface = leaf(AcceleratedParametricSurface(ZernikeSurface(9.5, aspherics = [(2, 0.0), (4, -0.001)]), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(ZernikeSurface(9.5, aspherics = [(2, 0.0), (4, -0.001)]), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 
 function coniclensZ()
-    topsurface = leaf(AcceleratedParametricSurface(ZernikeSurface(9.5, radius = -15.0, conic = -5.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(ZernikeSurface(9.5, radius = -15.0, conic = -5.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 
 function coniclensQ()
-    topsurface = leaf(AcceleratedParametricSurface(QTypeSurface(9.5, radius = -15.0, conic = -5.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(QTypeSurface(9.5, radius = -15.0, conic = -5.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 
 function qtypelens()
-    topsurface = leaf(AcceleratedParametricSurface(QTypeSurface(9.0, radius = -25.0, conic = 0.3, αcoeffs = [(1, 0, 0.3), (1, 1, 1.0)], βcoeffs = [(1, 0, -0.1), (2, 0, 0.4), (3, 0, -0.6)], normradius = 9.5), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(QTypeSurface(9.0, radius = -25.0, conic = 0.3, αcoeffs = [(1, 0, 0.3), (1, 1, 1.0)], βcoeffs = [(1, 0, -0.1), (2, 0, 0.4), (3, 0, -0.6)], normradius = 9.5), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 
 function chebyshevlens()
-    topsurface = leaf(AcceleratedParametricSurface(ChebyshevSurface(9.0, 9.0, [(1, 0, -0.081), (2, 0, -0.162), (0, 1, 0.243), (1, 1, 0.486), (2, 1, 0.081), (0, 2, -0.324), (1, 2, -0.405), (2, 2, -0.81)], radius = -25.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(ChebyshevSurface(9.0, 9.0, [(1, 0, -0.081), (2, 0, -0.162), (0, 1, 0.243), (1, 1, 0.486), (2, 1, 0.081), (0, 2, -0.324), (1, 2, -0.405), (2, 2, -0.81)], radius = -25.0), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 
 function gridsaglens()
-    topsurface = leaf(AcceleratedParametricSurface(GridSagSurface{Float64}(joinpath(@__DIR__, "../../test/test.GRD"), radius = -25.0, conic = 0.4, interpolation = GridSagBicubic), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
-    botsurface = leaf(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
-    barrel = leaf(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
+    topsurface = csgtransform(AcceleratedParametricSurface(GridSagSurface{Float64}(joinpath(@__DIR__, "../../test/test.GRD"), radius = -25.0, conic = 0.4, interpolation = GridSagBicubic), interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)), translation(0.0, 0.0, 5.0))
+    botsurface = csgtransform(Plane(0.0, 0.0, -1.0, 0.0, 0.0, -5.0, vishalfsizeu = 9.5, vishalfsizev = 9.5, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air)))
+    barrel = csgtransform(Cylinder(9.0, 20.0, interface = FresnelInterface{Float64}(OpticSim.GlassCat.SCHOTT.N_BK7, OpticSim.GlassCat.Air, reflectance = zero(Float64), transmission = zero(Float64))))
     return (barrel ∩ topsurface ∩ botsurface)(Transform{Float64}(0.0, Float64(π), 0.0, 0.0, 0.0, -5.0))
 end
 

--- a/test/testsets/Intersection.jl
+++ b/test/testsets/Intersection.jl
@@ -694,8 +694,8 @@
         @test isa(hit, DisjointUnion) && length(hit) == 2 && a && b
 
         # failure case, had a bug where rounding error would cause o2 to fail
-        o1 = leaf(AcceleratedParametricSurface(ZernikeSurface(1.4 * 1.15)), translation(0.0, 0.0, 3.0))()
-        o2 = leaf(AcceleratedParametricSurface(ZernikeSurface(1.4 * 1.15)), translation(2.0, 0.0, 3.0))()
+        o1 = csgtransform(AcceleratedParametricSurface(ZernikeSurface(1.4 * 1.15)), translation(0.0, 0.0, 3.0))()
+        o2 = csgtransform(AcceleratedParametricSurface(ZernikeSurface(1.4 * 1.15)), translation(2.0, 0.0, 3.0))()
         r = Ray([-5.0, 0.0, 0.0], [1.0, 0.0, 0.0])
         @test !(surfaceintersection(o1, r) isa EmptyInterval)
         @test !(surfaceintersection(o2, r) isa EmptyInterval)
@@ -890,7 +890,7 @@
 
         # test simple rays for intersection, union and difference operations
         # INTERSECTION
-        intersection_obj = (leaf(Cylinder(0.5, 3.0), OpticSim.rotationd(90.0, 0.0, 0.0)) ∩ Sphere(1.0))()
+        intersection_obj = (csgtransform(Cylinder(0.5, 3.0), OpticSim.rotationd(90.0, 0.0, 0.0)) ∩ Sphere(1.0))()
         r = Ray([0.7, 0.0, 0.0], [-1.0, 0.0, 0.0])
         int = OpticSim.evalcsg(intersection_obj, r)
         @test isapprox(point(lower(int)), [0.5, 0.0, 0.0], rtol = RTOLERANCE, atol = ATOLERANCE) && isapprox(point(upper(int)), [-0.5, 0.0, 0.0], rtol = RTOLERANCE, atol = ATOLERANCE)
@@ -942,7 +942,7 @@
         @test isapprox(point(lower(int)), [0.5, 0.0, 4.0], rtol = RTOLERANCE, atol = ATOLERANCE) && isapprox(point(upper(int)), [1.5, 0.0, 4.0], rtol = RTOLERANCE, atol = ATOLERANCE)
 
         # DIFFERENCE
-        difference_obj = (Cylinder(0.5, 3.0) - leaf(Sphere(1.0), OpticSim.translation(0.75, 0.0, 0.2)))()
+        difference_obj = (Cylinder(0.5, 3.0) - csgtransform(Sphere(1.0), OpticSim.translation(0.75, 0.0, 0.2)))()
         r = Ray([0.25, 0.0, 0.0], [-1.0, 0.0, 0.0])
         int = OpticSim.evalcsg(difference_obj, r)
         @test isapprox(point(lower(int)), [-0.2297958971132712, 0.0, 0.0], rtol = RTOLERANCE, atol = ATOLERANCE) && isapprox(point(upper(int)), [-0.5, 0.0, 0.0], rtol = RTOLERANCE, atol = ATOLERANCE)
@@ -969,7 +969,7 @@
 
         # DisjointUnion result on CSG
         surf = TestData.verywavybeziersurface()
-        accelsurf = leaf(AcceleratedParametricSurface(surf, 20))()
+        accelsurf = csgtransform(AcceleratedParametricSurface(surf, 20))()
 
         # five hits starting outside
         r = Ray([0.9, 0.0, -0.3], [0.0, 1.0, 0.7])

--- a/test/testsets/Visualization.jl
+++ b/test/testsets/Visualization.jl
@@ -9,15 +9,15 @@
         surf1 = AcceleratedParametricSurface(TestData.beziersurface(), 15)
         surf2 = AcceleratedParametricSurface(TestData.upsidedownbeziersurface(), 15)
         m = (
-            leaf(surf1, translation(-0.5, -0.5, 0.0)) ∩
+            csgtransform(surf1, translation(-0.5, -0.5, 0.0)) ∩
             Cylinder(0.3, 5.0) ∩
-            leaf(surf1, Transform{Float64}(0.0, Float64(π), 0.0, 0.5, -0.5, 0.0))
+            csgtransform(surf1, Transform{Float64}(0.0, Float64(π), 0.0, 0.5, -0.5, 0.0))
         )()
         @test_nowarn Vis.draw(m)
         m = (
-            leaf(surf1, translation(-0.5, -0.5, 0.0)) ∩
+            csgtransform(surf1, translation(-0.5, -0.5, 0.0)) ∩
             Cylinder(0.3, 5.0) ∩
-            leaf(surf2, translation(-0.5, -0.5, 0.0))
+            csgtransform(surf2, translation(-0.5, -0.5, 0.0))
         )()
         @test_nowarn Vis.draw(m)
         m = (Cylinder(0.5, 3.0) ∪ Sphere(1.0))()


### PR DESCRIPTION
After using the new interface a little bit, I don't think it's a good idea to have both `leaf` and `transform` available for applying transforms to CSG objects. Also `transform` is a popular name, both for variables and functions.

I'd suggest keeping `leaf` as a private method for converting a ParametricSurface into a CSGGenerator (without transforming), and changing `transform` to `csgtransform`, able to handle both ParametricSurface and CSGGenerator types.