### PR TITLE
draw_stackedbeamsplitters uses old leaf(...) function instead of new transform(...) function to apply a transform to a CSG node.

### DIFF
--- a/src/Examples/docs_examples.jl
+++ b/src/Examples/docs_examples.jl
@@ -225,23 +225,24 @@ function draw_stackedbeamsplitters(filenames::Vector{<:Union{Nothing,AbstractStr
 
     for (interfacemode, filename) in zip(interfacemodes, filenames)
         interface = FresnelInterface{Float64}(SCHOTT.N_BK7, Air; reflectance=0.5, transmission=0.5, interfacemode)
-        bs_1 = leaf(
-            leaf(
-                Cuboid(10.0, 20.0, 2.0; interface),
-                rotationX(π/4)),
-            translation(0.0, 0.0, -30.0-2*sqrt(2)))
-        l1 = leaf(
+        bs_1 = OpticSim.transform(
+                Cuboid(10.0, 20.0, 2.0, interface=interface),
+                translation(0.0, 0.0, -30.0-2*sqrt(2))*rotationX(π/4))
+
+        l1 = OpticSim.transform(
             SphericalLens(SCHOTT.N_BK7, -70.0, 30.0, Inf, 5.0, 10.0),
             translation(0.0, -1.34, 0.0))
-        bs_2 = leaf(
-            leaf(
-                Cuboid(10.0, 20.0, 2.0; interface),
-                rotationX(π/4)),
-            translation(0.0, 40.0, -30.0+2*sqrt(2)))
-        l2 = leaf(
+
+        bs_2 = OpticSim.transform(
+            Cuboid(10.0, 20.0, 2.0, interface=interface),
+            translation(0.0, 40.0, -30.0+2*sqrt(2))*rotationX(π/4))
+            
+        l2 = OpticSim.transform(
             SphericalLens(SCHOTT.N_BK7, -70.0, 30.0, Inf, 5.0, 10.0),
             translation(0.0, 40.0, 0.0))
+
         la = LensAssembly(bs_1(), l1(), bs_2(), l2())
+        
         detector = Rectangle(20.0, 40.0, SVector(0.0, 0.0, 1.0), SVector(0.0, 20.0, -130.0); interface = opaqueinterface())
         sys = CSGOpticalSystem(la, detector)
 


### PR DESCRIPTION
# Pull Request Template

## Description

deterministic ray tracing example wasn't working because draw_stackedbeamsplitters uses the old leaf(...) function to apply a transform to a CSG node rather than the new transform() function.

Fixes # (219)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran Documenter to create the documentation for the code and verified that the illustrations were correctly generated. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
