### PR TITLE
DataFrames.transform conflicts with Geometry.transform

### DIFF
--- a/src/Examples/Examples.jl
+++ b/src/Examples/Examples.jl
@@ -11,7 +11,7 @@ using ..OpticSim.Emitters
 using ..OpticSim.GlassCat
 
 using StaticArrays
-using DataFrames
+using DataFrames: DataFrame
 using Images
 using Unitful
 using Plots

--- a/src/Optical/Emitters/Spectrum.jl
+++ b/src/Optical/Emitters/Spectrum.jl
@@ -7,7 +7,7 @@ export Uniform, DeltaFunction, Measured
 
 using ....OpticSim
 using ...Emitters
-using DataFrames
+using DataFrames: DataFrame
 using Distributions
 import Unitful: Length, ustrip
 using Unitful.DefaultSymbols

--- a/src/Optical/OpticalSystem.jl
+++ b/src/Optical/OpticalSystem.jl
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # See LICENSE in the project root for full license information.
 
-using DataFrames: DataFrame
+using DataFrames: nrow
 using Unitful.DefaultSymbols
 using .OpticSim.GlassCat: AbstractGlass, TEMP_REF, PRESSURE_REF, Glass, Air
 

--- a/src/Optical/OpticalSystem.jl
+++ b/src/Optical/OpticalSystem.jl
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # See LICENSE in the project root for full license information.
 
-using DataFrames
+using DataFrames: DataFrame
 using Unitful.DefaultSymbols
 using .OpticSim.GlassCat: AbstractGlass, TEMP_REF, PRESSURE_REF, Glass, Air
 

--- a/test/Diagnostics/Diagnostics.jl
+++ b/test/Diagnostics/Diagnostics.jl
@@ -129,7 +129,7 @@ end
 
 using FiniteDifferences
 using ForwardDiff
-using DataFrames
+using DataFrames: DataFrame
 using Optim
 using JuMP
 using Ipopt

--- a/test/TestData/TestData.jl
+++ b/test/TestData/TestData.jl
@@ -12,7 +12,7 @@ using OpticSim: tobeziersegments # try to use only exported functions so this li
 using OpticSim.Geometry
 using OpticSim.Emitters
 using StaticArrays
-using DataFrames
+using DataFrames: DataFrame
 using Unitful
 using Images
 using Base: @.

--- a/test/testsets/GlassCat.jl
+++ b/test/testsets/GlassCat.jl
@@ -6,7 +6,7 @@ using Test
 using OpticSim.GlassCat
 
 using Base.Filesystem
-using DataFrames
+using DataFrames: DataFrame
 using StaticArrays
 using Unitful
 using Unitful.DefaultSymbols


### PR DESCRIPTION
# Pull Request Template

## Description

DataFrames defines a function transform which conflicts with our Geometry.transform. We only use two functions from DataFrames so need to change using and import statements to bring names in more selectively.

Fixes # (221)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

ran local unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
