### PR TITLE
fixing the nightly builds

### DIFF
--- a/src/Optical/Emitters/Directions.jl
+++ b/src/Optical/Emitters/Directions.jl
@@ -9,6 +9,7 @@ using ....OpticSim
 using ...Emitters
 using ...Geometry
 using LinearAlgebra
+using Random
 
 abstract type AbstractDirectionDistribution{T<:Real} end
 
@@ -110,15 +111,16 @@ struct UniformCone{T} <: AbstractDirectionDistribution{T}
     numsamples::Int64
     uvec::Vec3{T}
     vvec::Vec3{T}
+    rng::Random.AbstractRNG
 
-    function UniformCone(direction::Vec3{T}, θmax::T, numsamples::Int64) where {T<:Real}
+    function UniformCone(direction::Vec3{T}, θmax::T, numsamples::Int64; rng=Random.GLOBAL_RNG) where {T<:Real}
         (uvec, vvec) = get_orthogonal_vectors(direction)
-        return new{T}(direction, θmax, numsamples, uvec, vvec)
+        return new{T}(direction, θmax, numsamples, uvec, vvec, rng)
     end
 
-    function UniformCone(θmax::T, numsamples::Int64) where {T<:Real}
+    function UniformCone(θmax::T, numsamples::Int64; rng=Random.GLOBAL_RNG) where {T<:Real}
         direction = unitZ3(T)
-        return UniformCone(direction, θmax, numsamples)
+        return UniformCone(direction, θmax, numsamples, rng=rng)
     end
 end
 
@@ -129,8 +131,8 @@ function Emitters.generate(d::UniformCone{T}, ::Int64) where {T<:Real}
     uvec = d.uvec
     vvec = d.vvec
 
-    ϕ = rand(T) * 2π
-    θ = acos(clamp(one(T) + rand(T) * (cos(θmax) - 1), -one(T), one(T)))
+    ϕ = rand(d.rng, T) * 2π
+    θ = acos(clamp(one(T) + rand(d.rng, T) * (cos(θmax) - 1), -one(T), one(T)))
     return normalize(sin(θ) * (cos(ϕ) * uvec + sin(ϕ) * vvec) + cos(θ) * direction)
 end
 

--- a/src/Optical/Emitters/Origins.jl
+++ b/src/Optical/Emitters/Origins.jl
@@ -10,6 +10,7 @@ using ...Emitters
 using ...Geometry
 using LinearAlgebra
 using Distributions
+using Random
 
 abstract type AbstractOriginDistribution{T<:Real} end
 
@@ -63,9 +64,10 @@ struct RectUniform{T} <: AbstractOriginDistribution{T}
     width::T
     height::T
     samples_count::Int64
+    rng::Random.AbstractRNG
 
-    function RectUniform(width::T, height::T, samples_count::Int64) where {T<:Real}
-        return new{T}(width, height, samples_count)
+    function RectUniform(width::T, height::T, samples_count::Int64; rng=Random.GLOBAL_RNG) where {T<:Real}
+        return new{T}(width, height, samples_count, rng)
     end
 end
 
@@ -75,8 +77,8 @@ Emitters.visual_size(o::RectUniform) = max(o.width, o.height)
 # generate origin on the agrid
 function Emitters.generate(o::RectUniform{T}, n::Int64) where {T<:Real}
     n = mod(n, length(o))
-    u = rand(Distributions.Uniform(-one(T), one(T)))
-    v = rand(Distributions.Uniform(-one(T), one(T)))
+    u = rand(o.rng, Distributions.Uniform(-one(T), one(T)))
+    v = rand(o.rng, Distributions.Uniform(-one(T), one(T)))
     return zero(Vec3{T}) + ((o.width / 2) * u * unitX3(T)) + ((o.height/2) * v * unitY3(T))
 end
 

--- a/src/Optical/Emitters/Spectrum.jl
+++ b/src/Optical/Emitters/Spectrum.jl
@@ -11,6 +11,7 @@ using DataFrames: DataFrame
 using Distributions
 import Unitful: Length, ustrip
 using Unitful.DefaultSymbols
+using Random
 
 const UNIFORMSHORT = 0.450 #um
 const UNIFORMLONG = 0.680 #um
@@ -30,19 +31,20 @@ Uniform(::Type{T} = Float64) where {T<:Real}
 struct Uniform{T} <: AbstractSpectrum{T}
     low_end::T
     high_end::T 
+    rng::Random.AbstractRNG
 
     # user defined range of spectrum
-    function Uniform(low_end::T, high_end::T) where {T<:Real}
-        return new{T}(low_end, high_end)
+    function Uniform(low_end::T, high_end::T; rng=Random.GLOBAL_RNG) where {T<:Real}
+        return new{T}(low_end, high_end, rng)
     end
 
     # with no specific range we will use the constants' values
-    function Uniform(::Type{T} = Float64) where {T<:Real}
-        return new{T}(UNIFORMSHORT, UNIFORMLONG)
+    function Uniform(::Type{T} = Float64; rng=Random.GLOBAL_RNG) where {T<:Real}
+        return new{T}(UNIFORMSHORT, UNIFORMLONG, rng)
     end
 end
 
-Emitters.generate(s::Uniform{T}) where {T<:Real} = (one(T), rand(Distributions.Uniform(s.low_end, s.high_end)))
+Emitters.generate(s::Uniform{T}) where {T<:Real} = (one(T), rand(s.rng, Distributions.Uniform(s.low_end, s.high_end)))
 
 """
     DeltaFunction{T} <: AbstractSpectrum{T}

--- a/test/testsets/Emitters.jl
+++ b/test/testsets/Emitters.jl
@@ -76,8 +76,8 @@ using StaticArrays
             @test Directions.UniformCone(0., 0).vvec === unitY3()
 
             @test Base.length(Directions.UniformCone(0., 1)) === 1
-            Random.seed!(0)
-            @test collect(Directions.UniformCone(π/4, 2)) == [
+            
+            @test collect(Directions.UniformCone(π/4, 2, rng=Random.MersenneTwister(0))) == [
                 [0.30348115383395624, -0.6083405920618145, 0.7333627433388552],
                 [0.16266571675478964, 0.2733479444418462, 0.9480615833700192],
             ]
@@ -131,8 +131,7 @@ using StaticArrays
             @test Base.length(Origins.RectUniform(1, 2, 3)) === 3
             @test Emitters.visual_size(Origins.RectUniform(1, 2, 3)) === 2
 
-            Random.seed!(0)
-            @test collect(Origins.RectUniform(1, 2, 3)) == [
+            @test collect(Origins.RectUniform(1, 2, 3, rng=Random.MersenneTwister(0))) == [
                 [0.3236475079774124, 0.8207130758528729, 0.0],
                 [-0.3354342018663148, -0.6453423070674709, 0.0],
                 [-0.221119890668799, -0.5930468839161547, 0.0],
@@ -191,8 +190,7 @@ using StaticArrays
             @test Spectrum.Uniform().low_end === 0.450
             @test Spectrum.Uniform().high_end === 0.680
 
-            Random.seed!(0)
-            @test Emitters.generate(Spectrum.Uniform()) === (1.0, 0.6394389268348049)
+            @test Emitters.generate(Spectrum.Uniform(rng=Random.MersenneTwister(0))) === (1.0, 0.6394389268348049)
         end
 
         @testset "DeltaFunction" begin
@@ -236,16 +234,12 @@ using StaticArrays
                 directions=Directions.HexapolarCone(0., 1)
             )) === 49
 
-            Random.seed!(0)
-            @test Base.iterate(Sources.Source()) === (expected_rays[1], Sources.SourceGenerationState(2, 0, Vec3()))
+            @test Base.iterate(Sources.Source(spectrum=Spectrum.Uniform(rng=Random.MersenneTwister(0)))) === (expected_rays[1], Sources.SourceGenerationState(2, 0, Vec3()))
 
-            Random.seed!(0)
-            @test Base.getindex(Sources.Source(), 0) === expected_rays[1]
-            Random.seed!(0)
-            @test Emitters.generate(Sources.Source(), 0) === expected_rays[1]
+            @test Base.getindex(Sources.Source(spectrum=Spectrum.Uniform(rng=Random.MersenneTwister(0))), 0) === expected_rays[1]
+            @test Emitters.generate(Sources.Source(spectrum=Spectrum.Uniform(rng=Random.MersenneTwister(0))), 0) === expected_rays[1]
 
-            Random.seed!(0)
-            @test Emitters.generate(Sources.Source()) === (expected_rays[1], Sources.SourceGenerationState(0, -2, Vec3()))
+            @test Emitters.generate(Sources.Source(spectrum=Spectrum.Uniform(rng=Random.MersenneTwister(0)))) === (expected_rays[1], Sources.SourceGenerationState(0, -2, Vec3()))
 
             @test Base.firstindex(Sources.Source()) === 0
             @test Base.lastindex(Sources.Source()) === 0
@@ -253,7 +247,7 @@ using StaticArrays
         end
 
         @testset "CompositeSource" begin
-            s() = Sources.Source()
+            s() = Sources.Source(spectrum=Spectrum.Uniform(rng=Random.MersenneTwister(0)))
             tr = Transform()
             cs1 = Sources.CompositeSource(tr, [s()])
             cs2 = Sources.CompositeSource(tr, [s(), s()])
@@ -277,14 +271,11 @@ using StaticArrays
             @test Base.length(cs2) === 2
             @test Base.length(cs3) === 3
 
-            Random.seed!(0)
             @test Base.iterate(cs1) === (expected_rays[1], Sources.SourceGenerationState(2, 0, Vec3()))
 
-            Random.seed!(0)
-            @test collect(cs2) == expected_rays[1:2]
+            @test collect(cs2) == vcat(expected_rays[1:1], expected_rays[1:1])
 
-            Random.seed!(0)
-            @test collect(cs3) == expected_rays[1:3]
+            @test collect(cs3) == vcat(expected_rays[1:1], expected_rays[2:2], expected_rays[2:2])
         end
     end
 end # testset Emitters


### PR DESCRIPTION
added the capability to supply a random generator to random direction generator (UniformCone) and the random rectangle position generator (RectUniform).
Added random generator to Spectrum.Uniform too.
Modified the emiiters tests to use the specific random number generator to produce trhe expected results.

this will allow us to define the correct generator using the tests regardless of any changes to the default random generator in the future.