### PR TITLE
Luxor figures in documenter

### DIFF
--- a/docs/src/repeat.md
+++ b/docs/src/repeat.md
@@ -40,21 +40,24 @@ The [`rectangularlattice`](@ref sources) function creates a rectangular lattice 
 There are a few visualization functions for special 2D lattices. [`Vis.drawhexcells`](@ref sources) draws a set of hexagonal cells. Using [`Repeat.hexcellsinbox`](@ref sources) we can draw all the hexagonal cells that fit in a rectangular box:
 
 ```@example 
- using OpticSim, Luxor
- @svg Vis.drawhexcells(50,Repeat.hexcellsinbox(2,2))
+using OpticSim
+Vis.drawhexcells(50,Repeat.hexcellsinbox(2,2))
+HTML(Vis.drawhexcells(50,Repeat.hexcellsinbox(2,2), format=:svg)) #hide
 ```
 
 There is also a function to compute the n rings of a cell x, i.e., the cells which can be reached by taking no more than n steps along the lattice from x:
 
 ```@example 
- using OpticSim, Luxor
- @svg Vis.drawhexcells(50,Repeat.neighbors(Repeat.HexBasis1,(0,0),2))
- ```
+using OpticSim
+Vis.drawhexcells(50,Repeat.neighbors(Repeat.HexBasis1,(0,0),2))
+HTML(Vis.drawhexcells(50,Repeat.neighbors(Repeat.HexBasis1,(0,0),2), format=:svg)) #hide
+```
  
- You can also draw all the cells contained within an n ring:
+You can also draw all the cells contained within an n ring:
  
- ```@example 
- using OpticSim, Luxor
- @svg Vis.drawhexcells(50,Repeat.region(Repeat.HexBasis1,(0,0),2))
- ```
+```@example 
+using OpticSim
+Vis.drawhexcells(50,Repeat.region(Repeat.HexBasis1,(0,0),2))
+HTML(Vis.drawhexcells(50,Repeat.region(Repeat.HexBasis1,(0,0),2), format=:svg)) #hide
+```
 

--- a/src/Vis/VisRepeatingStructures.jl
+++ b/src/Vis/VisRepeatingStructures.jl
@@ -36,8 +36,9 @@ function drawhex(hexbasis::Repeat.Basis,hexsize,i,j,color)
     Luxor.translate(-offset)
 end
 
-function drawhexcells(hexsize,cells, color::Union{AbstractArray,Nothing} = nothing)
-    Luxor.Drawing(500, 500, :svg)
+function drawhexcells(hexsize,cells, color::Union{AbstractArray,Nothing} = nothing; format=:png)
+    Luxor.Drawing(500, 500, format)
+    Luxor.origin()
     if color === nothing
         distcolors = Colors.distinguishable_colors(length(cells),lchoices = range(40,stop=100,length = 15))
             for (i,cell) in pairs(cells)
@@ -48,7 +49,14 @@ function drawhexcells(hexsize,cells, color::Union{AbstractArray,Nothing} = nothi
             drawhex(Repeat.HexBasis1(),hexsize,cell[1],cell[2],color[i])
         end
     end
+    if (format == :png)
+        res = RGB.(Luxor.image_as_matrix())
+    end
     Luxor.finish()
+    if (format == :svg)
+        res = Luxor.svgstring()
+    end
+    return res
 end
 
 function draw(lattice::Repeat.Basis, scale = 50.0)


### PR DESCRIPTION
added the ability to produce a repeatable drawing in different formats: png and svg to better support the docs creation.

@BrianGun take a look at the examples in repeat.md