### PR TITLE
color("$c") -> colorant"$c"

### DIFF
--- a/src/Examples/repeating_structure_examples.jl
+++ b/src/Examples/repeating_structure_examples.jl
@@ -37,7 +37,7 @@ end
 """ Create a ClusterWithProperties with three types of elements, R,G,B """
 function hex3RGB()
     clusterelements = SVector((0,0),(-1,0),(-1,1))
-    colors = [color("red"),color("green"),color("blue")]
+    colors = [colorant"red",colorant"green",colorant"blue"]
     names = ["R","G","B"]
     eltlattice = HexBasis1()
     clusterbasis = LatticeBasis(( -1,2),(2,-1))
@@ -49,7 +49,7 @@ end
 """ Create a ClusterWithProperties with four types of elements, R,G,B,W """
 function hexRGBW()
     clusterelements = SVector((0,0),(-1,0),(-1,1),(0,-1))
-    colors = [color("red"),color("green"),color("blue"),color("white")]
+    colors = [colorant"red",colorant"green",colorant"blue",colorant"white"]
     names = ["R","G","B","W"]
     eltlattice = HexBasis1()
     clusterbasis = LatticeBasis((0,2),(2,-2))
@@ -65,9 +65,9 @@ function hex12RGB()
         (-1,-1),(0,-1),(1,-1),(2,-1),
         (0,-2),(1,-2),(2,-2)
     )
-    red = color("red")
-    grn = color("green")
-    blu = color("blue")
+    red = colorant"red"
+    grn = colorant"green"
+    blu = colorant"blue"
     colors = [
         grn,blu,
         blu,red,grn,

--- a/test/testsets/Visualization.jl
+++ b/test/testsets/Visualization.jl
@@ -12,28 +12,33 @@
         # test that this all at least runs
         surf1 = AcceleratedParametricSurface(TestData.beziersurface(), 15)
         surf2 = AcceleratedParametricSurface(TestData.upsidedownbeziersurface(), 15)
+
         m = (
             leaf(surf1, translation(-0.5, -0.5, 0.0)) ∩
             Cylinder(0.3, 5.0) ∩
             leaf(surf1, Transform{Float64}(0.0, Float64(π), 0.0, 0.5, -0.5, 0.0))
         )()
+        Vis.draw(m)
         @test_nowarn Vis.draw(m)
+
         m = (
             leaf(surf1, translation(-0.5, -0.5, 0.0)) ∩
             Cylinder(0.3, 5.0) ∩
             leaf(surf2, translation(-0.5, -0.5, 0.0))
         )()
         @test_nowarn Vis.draw(m)
+
         m = (Cylinder(0.5, 3.0) ∪ Sphere(1.0))()
         @test_nowarn Vis.draw(m)
+
         m = (Cylinder(0.5, 3.0) ∩ Sphere(1.0))()
         @test_nowarn Vis.draw(m)
+
         m = (Cylinder(0.5, 3.0) - Sphere(1.0))()
         @test_nowarn Vis.draw(m)
 
         @test_nowarn Vis.draw(Examples.hex3RGB(),[0 1 0;0 0 1])
         @test_nowarn Examples.drawhexrect()
         @test_nowarn Examples.drawhexneighbors()
-
     end
 end # testset Visualization


### PR DESCRIPTION
`color("$c")` is deprecated. This is throwing a warning that causes some tests to fail.