### PR TITLE
Update documentation to use drawcells instead of drawhexcells

### DIFF
--- a/docs/src/repeat.md
+++ b/docs/src/repeat.md
@@ -20,7 +20,7 @@ tilevertices(a::S) where{S<:Basis}
 A lattice is described by a set of lattice vectors eᵢ which are stored in a [`Basis`](@ref sources) object. You can create bases in any dimension. Points in the lattice are indexed by integer coordinates. These lattice coordinates can be converted to Cartesian coordinates by indexing the LatticeBasis object. 
 ``` @example example
 using OpticSim, OpticSim.Repeat
-a = LatticeBasis([1.0,5.0],[0.0,1.0])
+a = LatticeBasis((1.0,5.0),(0.0,1.0))
 a[3,3]
 ```
 

--- a/docs/src/repeat.md
+++ b/docs/src/repeat.md
@@ -37,24 +37,24 @@ basis(HexBasis1())
 ```
 The [`rectangularlattice`](@ref sources) function creates a rectangular lattice basis. 
 
-There are a few visualization functions for special 2D lattices. [`Vis.drawhexcells`](@ref sources) draws a set of hexagonal cells. Using [`Repeat.hexcellsinbox`](@ref sources) we can draw all the hexagonal cells that fit in a rectangular box:
+There are a few visualization functions for special 2D lattices. [`Vis.drawcells`](@ref sources) draws a set of hexagonal cells. Using [`Repeat.hexcellsinbox`](@ref sources) we can draw all the hexagonal cells that fit in a rectangular box:
 
 ```@example 
 using OpticSim
-Vis.drawhexcells(50,Repeat.hexcellsinbox(2,2))
+Vis.drawcells(Repeat.HexBasis1(),50,Repeat.hexcellsinbox(2,2))
 ```
 
 There is also a function to compute the n rings of a cell x, i.e., the cells which can be reached by taking no more than n steps along the lattice from x:
 
 ```@example 
 using OpticSim
-Vis.drawhexcells(50,Repeat.neighbors(Repeat.HexBasis1,(0,0),2))
+Vis.drawcells(Repeat.HexBasis1(),50,Repeat.neighbors(Repeat.HexBasis1,(0,0),2))
 ```
  
 You can also draw all the cells contained within an n ring:
  
 ```@example 
 using OpticSim
-Vis.drawhexcells(50,Repeat.region(Repeat.HexBasis1,(0,0),2))
+Vis.drawcells(Repeat.HexBasis1(),50,Repeat.region(Repeat.HexBasis1,(0,0),2))
 ```
 

--- a/src/Vis/VisRepeatingStructures.jl
+++ b/src/Vis/VisRepeatingStructures.jl
@@ -10,7 +10,7 @@
 
 # lattice visualizations are drawn with Luxor because it is easier to do 2D drawings with Luxor than with Makie.
 
-function draw(tilebasis::Basis,tilesize,i,j,color,name)
+function draw(tilebasis::Basis,tilesize,i,j,color,name) 
     vertices = Repeat.tilevertices(tilebasis)
     tile = tilesize*[Luxor.Point(vertices[:,i]...) for i in 1:size(vertices)[2]]
     pt = tilesize*tilebasis[i,j]

--- a/src/Vis/VisRepeatingStructures.jl
+++ b/src/Vis/VisRepeatingStructures.jl
@@ -10,7 +10,7 @@
 
 # lattice visualizations are drawn with Luxor because it is easier to do 2D drawings with Luxor than with Makie.
 
-function draw(tilebasis::Basis,tilesize,i,j,color,name) 
+function draw(tilebasis::Basis,tilesize,i,j,color,name)
     vertices = Repeat.tilevertices(tilebasis)
     tile = tilesize*[Luxor.Point(vertices[:,i]...) for i in 1:size(vertices)[2]]
     pt = tilesize*tilebasis[i,j]


### PR DESCRIPTION
Fixes #281
Fixes #280

fixed call to Vis.drawcells to use the new interface instead of Vis.drawhexcells

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

verified that documentation has correct figures after the change



## Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
