### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6','1.7-rc3']
+        version: ['1.6','1.7.0-rc3']
         os: [ubuntu-latest, windows-latest]
         arch: [x64]
         include:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6','1.7']
+        version: ['1.6','1.7-rc3']
         os: [ubuntu-latest, windows-latest]
         arch: [x64]
         include:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6']
+        version: ['1.6','1.7']
         os: [ubuntu-latest, windows-latest]
         arch: [x64]
         include:


### PR DESCRIPTION
Added Julia 1.7.0-rc3 to set of versions to run CI against.

We will switch to 1.7 soon so we should start testing against the latest release candidate.