### PR TITLE
Replace hcat with new matrix literal syntax to create column vectors

### DIFF
--- a/src/Vis/VisRepeatingStructures.jl
+++ b/src/Vis/VisRepeatingStructures.jl
@@ -63,16 +63,16 @@ function drawcells(tilebasis::AbstractBasis, tilesize, cells::AbstractMatrix; co
 end
 
 """ draw the LatticeCluster offset to (0,0) """
-draw(clstr::LatticeCluster,tilesize=50.0, cells=hcat([0,0])) = drawcells(clstr.elementbasis, tilesize, clustercoordinates(clstr, 0, 0))
+draw(clstr::LatticeCluster, cluster_coordinate_offset=[0;0;;], scale=50.0) = drawcells(clstr.elementbasis, scale, clustercoordinates(clstr, cluster_coordinate_offset[1,1],cluster_coordinate_offset[2,1]))
 
-""" draw the ClusterWithProperties at coordinates specified by cells """
-function draw(clstr::Repeat.ClusterWithProperties, cells=hcat([0,0]), scale=50.0) # this is how you have to make a 2x1 matrix. One would expect [0;0] to work but it doesn't.
-    dims = size(cells)
+""" draw the ClusterWithProperties at coordinates specified by lattice_coordinate_offset """
+function draw(clstr::Repeat.ClusterWithProperties, cluster_coordinate_offset=[0;0;;], scale=50.0) # this is how you have to make a 2x1 matrix. One would expect [0;0] to work but it doesn't.
+    dims = size(cluster_coordinate_offset)
     @assert dims[1] == 2 "dims[1] must be 2 instead was $(dims[1])"
     clstrsize = clustersize(clstr)
     points = Matrix(undef, dims[1], dims[2] * clstrsize)
     for i in 1:dims[2]
-        points[:,(i - 1) * clstrsize + 1:i * clstrsize] = clustercoordinates(clstr, cells[1,i], cells[2,i])
+        points[:,(i - 1) * clstrsize + 1:i * clstrsize] = clustercoordinates(clstr, cluster_coordinate_offset[1,i], cluster_coordinate_offset[2,i])
     end
     props = repeat(Repeat.properties(clstr), dims[2])
     drawcells(elementbasis(cluster(clstr)), scale, points, color=props[:,:Color], name=props[:,:Name])


### PR DESCRIPTION
Fixes #337

Prior to 1.7 to create a 2x1 matrix you did this: hcat([0,0]). In 1.7 you do this: [0;0;;] which is clearer and more efficient.



# Pull Request Template

## Description

changed hcat([0,0]) to [0;0;;] in draw functions for LatticeCluster and ClusterWithProperties. Also changed draw(::LatticeCluster) function to have the scale argument come last so the two cluster draw functions are consistent.

Fixes # (336)


## How Has This Been Tested?
 verified that both cluster draw functions work with the new array literal syntax.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
