### PR TITLE
Fix typo in Zernike.jl

### DIFF
--- a/src/Geometry/Primitives/Zernike.jl
+++ b/src/Geometry/Primitives/Zernike.jl
@@ -297,7 +297,7 @@ function AcceleratedParametricSurface(surf::T, numsamples::Int = 17; interface::
 end
 
 function BoundingBox(surf::ZernikeSurface{T,3,P,Q,M}) where {T<:Real,P,Q,M}
-    bb = BoundingBox(z.asp)
+    bb = BoundingBox(surf.asp)
     # zernike terms have condition than |Zᵢ| <= 1
     # so this gives us a (loose) bounding box
     ak = P > 0 ? sum(abs.(Zernike.normalisation(T, n, m) * k for (n, m, k) in surf.coeffs)) : zero(T)


### PR DESCRIPTION
Turned up in https://github.com/aviatesk/JET.jl/issues/225

~~Surprised this wasn't caught somewhere, make we aren't calling bounding box on a zernike surface anywhere?
I feel like we should be for any CSG object with a zernike surface in though... maybe worth looking into~~

We call BoundingBox on the accelerated (ie triangulated) surface wrapping the zernike surface which gives a much tighter bounding box - so this is never actually called