### PR TITLE
Fix placement of lenslet displays

### DIFF
--- a/src/RepeatingStructures/Multilens/Example.jl
+++ b/src/RepeatingStructures/Multilens/Example.jl
@@ -142,13 +142,23 @@ function testspherelenslets()
 end
 export testspherelenslets
 
-function draw_projected_eyeboxes(system = setup_nominal_system())
-    (;projected_eyeboxes,lenslet_eyebox_numbers,subdivisions_of_eyebox) = system
+function draw_projected_corners(system = setup_nominal_system())
+    (;lenslet_eye_boxes, lenslet_eyebox_numbers,subdivisions_of_eyebox,lenses,displayplanes) = system
     colors = distinguishable_colors(reduce(*,subdivisions_of_eyebox))
 
-    for projected_eyebox in projected_eyeboxes
-        Vis.draw!(ConvexPolygon(identitytransform(),))
+    for (lenslet_eyebox,lenslet_eyebox_number,lens,display_plane) in zip(lenslet_eye_boxes,lenslet_eyebox_numbers,lenses,displayplanes)
+        center = opticalcenter(lens)
+        for eyeboxpt in eachcol(lenslet_eyebox)
+            r = Ray(eyeboxpt,center-eyeboxpt)
+            intsct = surfaceintersection(display_plane,r)
+            closest = closestintersection(intsct)
+            display_intersection = point(closest)
+            lenstrace = LensTrace(OpticalRay(r,1.0,.5),closest)
+            Vis.draw!(lenstrace)
+        end
+    end
 end
+export draw_projected_corners
 
 """assigns each lenslet/display subsystem a rectangular sub part of the eyebox"""
 function draw_eyebox_assignment(system = setup_nominal_system(),clear_screen = true;draw_eyebox = true)
@@ -202,6 +212,7 @@ function draw_system(system = setup_nominal_system())
     draw_subdivided_eyeboxes(system,false)
     # Vis.draw!(compute_eyebox_rays(system))
     draw_eyebox_rays(system)
+    draw_projected_corners(system)
 
     # for lens in system.lenses
     #     nrml = -normal(lens)

--- a/src/RepeatingStructures/Multilens/Example.jl
+++ b/src/RepeatingStructures/Multilens/Example.jl
@@ -142,6 +142,14 @@ function testspherelenslets()
 end
 export testspherelenslets
 
+function draw_projected_eyeboxes(system = setup_nominal_system())
+    (;projected_eyeboxes,lenslet_eyebox_numbers,subdivisions_of_eyebox) = system
+    colors = distinguishable_colors(reduce(*,subdivisions_of_eyebox))
+
+    for projected_eyebox in projected_eyeboxes
+        Vis.draw!(ConvexPolygon(identitytransform(),))
+end
+
 """assigns each lenslet/display subsystem a rectangular sub part of the eyebox"""
 function draw_eyebox_assignment(system = setup_nominal_system(),clear_screen = true;draw_eyebox = true)
     (;eyebox_rectangle,
@@ -232,17 +240,18 @@ function test_project_eyebox_to_display_plane()
         1.0,-1.0,0.0,
         -1.0,-1.0,0.0
         )
-    correct_answer = SMatrix{3,4}(0.15, -0.15, 11.5, 
-    -0.15, -0.15, 11.5, 
-    -0.15, 0.15, 11.5, 
-    0.15, 0.15, 11.5)
+    correct_answer = SMatrix{3,4}(
+        1.3,1.0, 11.5, 
+        1.0,1.0, 11.5, 
+        1.0,1.3, 11.5, 
+        1.3,1.3, 11.5)
     fl = 1.5
-    lenscenter = [0.0,0.0,10.0]
-    lens = ParaxialLensRect(fl,.5,.5,[0.0,0.0,-1.0],lenscenter)
-    displayplane = Plane([0.0,0.0,-1.0],[0.0,0.0,lenscenter[3]+fl])
+    lenscenter = [1.0,1.0,10.0]
+    lens = ParaxialLensRect(fl,.5,.5,[0.0,0.0,1.0],lenscenter)
+    displayplane = Plane([0.0,0.0,1.0],[0.0,0.0,lenscenter[3]+fl])
 
     answer = project_eyebox_to_display_plane(boxpoly,lens,displayplane)
-    @assert isapprox(answer,correct_answer)
+    @assert isapprox(answer,correct_answer) "computed points $answer"
 end
 export test_project_eyebox_to_display_plane
 

--- a/src/RepeatingStructures/Multilens/LensletAssignment.jl
+++ b/src/RepeatingStructures/Multilens/LensletAssignment.jl
@@ -250,10 +250,8 @@ function setup_system(eye_box,fov,eye_relief,pupil_diameter,display_sphere_radiu
 
     # @info "reprojected points $(repropoints)"
 
-    #project eyebox into lenslet display plane and compute bounding box. This is the size of the display for this lenslet
+    #make as many subdivided eyebox polygons as are necessary to cover all the lenses
     subdivs = extend(lenses,subdivided_eyeboxpolys)
-   
-   
 
     
     projected_eyeboxes = project_eyebox_to_display_plane.(subdivs,lenses,displayplanes) #repeate subdivided_eyeboxpolys enough times to cover all lenses

--- a/src/RepeatingStructures/Multilens/LensletAssignment.jl
+++ b/src/RepeatingStructures/Multilens/LensletAssignment.jl
@@ -83,7 +83,7 @@ end
 """returns display plane represented in world coordinates, and the center point of the display"""
 function display_plane(lens) 
     center_point = centroid(lens) + -OpticSim.normal(lens)* OpticSim.focallength(lens)
-    pln = Plane(OpticSim.normal(lens), center_point, vishalfsizeu = .5, vishalfsizev = .5)
+    pln = Plane(OpticSim.normal(lens), center_point, vishalfsizeu = .5, vishalfsizev = .5,interface = opaqueinterface())
     return pln,center_point
 end
 export display_plane
@@ -146,7 +146,9 @@ function project_eyebox_to_display_plane(eyeboxpoly::AbstractMatrix{T},lens,disp
     
     points = collect([point(closestintersection(surfaceintersection(displayplane,ray),false)) for ray in rays])
 
-    SMatrix{rowdim,coldim}(reinterpret(Float64,points)...)
+    eyebox = SMatrix{rowdim,coldim}(reinterpret(Float64,points)...)
+    twoDpts, toworld, tolocal = projectonbestfitplane(eyebox,[0.0,0.0,1.0])
+    return eyebox,ConvexPolygon(toworld,twoDpts,opaqueinterface())
 end
 
 """System parameters for a typical HMD."""


### PR DESCRIPTION
Fixes #356

moved replacement of optic center of lenlets before the computation of projected eyeboxes, since the latter depends on the former.

adding more drawing functions to Example.jl so individual parts of system computation can be drawn.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration(s)**:

* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
