### PR TITLE
Warning about Schott glasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ This software provides extensive control over the modelling, simulation, visuali
 
 Before you can use the software you will need to download glass files. See the documentation for detailed information about how to do this.
 
+*Warning*: During installation OpticSim automatically downloads glass catalogs from a variety of public sources. The Schott website keeps moving their catalog on their website so our software can't find it to download. This caused all our examples to fail because they use Schott glasses. We have replaced the glasses in the examples with hard coded glass files so all examples now work (if they don't file an issue). 
+
+**If you want to use Schott glasses you will have to manually download and install the Schott catalog.**
+
 ## Contributing
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)


### PR DESCRIPTION
Fixes #395

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

During installation OpticSim automatically downloads glass catalogs from a variety of public sources. The Schott website keeps moving their catalog on their website so our software can't find it to download. This caused all our examples to fail because they use Schott glasses. A previous PR replaced the glasses in the examples with hard coded glass files so all examples now work (if they don't file an issue). 

This PR just updates the README.md document to warn users about this problem.


## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [na ] I have added tests that prove my fix is effective or that my feature works
- [na ] New and existing unit tests pass locally with my changes
- [na ] Any dependent changes have been merged and published in downstream modules
- [x ] I have checked my code and corrected any misspellings
