### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/docs/src/basic_types.md
+++ b/docs/src/basic_types.md
@@ -1,6 +1,6 @@
 # Basic Types
 
-The following are basic geometric types and utilities, such as vectors and transforms, that are used all acoross the package. Using these types requires, in addition to the `using OpticSim` statement to also use the OpticSim.Geoemtry module like:
+The following are basic geometric types and utilities, such as vectors and transforms, that are used all acoross the package. Using these types requires, in addition to the `using OpticSim` statement to also use the OpticSim.Geometry module like:
 
 ```@example
 using OpticSim, OpticSim.Geometry

--- a/samples/notebooks/BasicCSG.jl
+++ b/samples/notebooks/BasicCSG.jl
@@ -103,7 +103,7 @@ begin
 	csg1_surf2 = leaf(csg1_surf1, OpticSim.translation(-0.5, -0.5, 0.0))
 	csg1_surf3 = leaf(csg1_surf1, Transform(0.0, Float64(π), 0.0, 0.5, -0.5, 0.0))
 	
-	# transformed cilinder
+	# transformed cylinder
 	csg1_surf4_1 = leaf(Cylinder(0.3, 1.0), OpticSim.translation(0.0, 0.0, 0.0))
 	csg1_surf4 = leaf(csg1_surf4_1, OpticSim.rotation(deg2rad(cyl_rot_x), deg2rad(cyl_rot_y), deg2rad(cyl_rot_z)))
 	

--- a/samples/notebooks/EmittersIntro.jl
+++ b/samples/notebooks/EmittersIntro.jl
@@ -90,7 +90,7 @@ The OpticSim package comes with various implementations of each of these basic e
   * **Point** - a single point
   * **RectUniform** - a uniformly sampled rectangle with user defined number of samples
   * **RectGrid** - a rectangle sampled in a grid fashion
-  * **Hexapolar** - a circle (or an ellipse) sampled in an hexapolar fasion (rings)
+  * **Hexapolar** - a circle (or an ellipse) sampled in an hexapolar fashion (rings)
 - Rays Directions Distribution - the interface **length** returns the number of samples, and **generate** returns the n'th sample.
   * **Constant**
   * **RectGrid**

--- a/src/Data/HumanEye.jl
+++ b/src/Data/HumanEye.jl
@@ -38,7 +38,7 @@ export 𝐃sd
 eyeradius() = 12mm
 export eyeradius
 
-"""Posterior focal length, i.e., optical distance from entrance pupil to the retina. Focal length will change depending on accomodation. This value is for focus at ∞. When the eye is focused at 25cm focal length will be ≈ 22mm. Because the index of refraction of the vitreous humor is approximately 1.33 the physical distance from the entrance pupil to the retina will be 24mm/1.33 = 18mm."""
+"""Posterior focal length, i.e., optical distance from entrance pupil to the retina. Focal length will change depending on accommodation. This value is for focus at ∞. When the eye is focused at 25cm focal length will be ≈ 22mm. Because the index of refraction of the vitreous humor is approximately 1.33 the physical distance from the entrance pupil to the retina will be 24mm/1.33 = 18mm."""
 eyefocallength() = 24mm
 export eyefocallength
 

--- a/src/Examples/repeating_structure_examples.jl
+++ b/src/Examples/repeating_structure_examples.jl
@@ -26,7 +26,7 @@ function drawhexrectcolors()
     Vis.drawcells(Repeat.HexBasis1(),30,cells)
 end
 
-""" Create a LatticeCluser with three elements at (0,0),(-1,0),(-1,1) coordinates in the HexBasis1 lattice"""
+""" Create a LatticeCluster with three elements at (0,0),(-1,0),(-1,1) coordinates in the HexBasis1 lattice"""
 function hex3cluster()
     clusterelts = SVector((0,0),(-1,0),(-1,1))
     eltlattice = HexBasis1()

--- a/src/Geometry/AnalyticIntersection.jl
+++ b/src/Geometry/AnalyticIntersection.jl
@@ -131,7 +131,7 @@ end
 function eigenresults(rline::AbstractRay{T,N}, curve::Array{T,2}) where {T<:Real,N} # force rline and curve to use same number type to avoid expensive runtime conversion.
     dim = curvedimension(curve)
     orderofcurve = curveorder(curve)
-    movinglineorder = max(orderofcurve, Int64(ceil(orderofcurve * 2 / dim - 1))) # Hve two constraints for movingline order. Must be big enough to result in a nullspace >= orderofcurve for the first step of computing the moving lines. Also need need at least as many eigenvalues as possible intersections of the line with the curve. Eigenmatrix is square of size qgxqg so need this matrix to be at least of size qx by qx. Take the greater of the the two constraint values.
+    movinglineorder = max(orderofcurve, Int64(ceil(orderofcurve * 2 / dim - 1))) # Have two constraints for movingline order. Must be big enough to result in a nullspace >= orderofcurve for the first step of computing the moving lines. Also need need at least as many eigenvalues as possible intersections of the line with the curve. Eigenmatrix is square of size qgxqg so need this matrix to be at least of size qx by qx. Take the greater of the the two constraint values.
 
     cmat = orthogonalitymatrix(curve, movinglineorder)
 

--- a/src/Geometry/CSG/CSG.jl
+++ b/src/Geometry/CSG/CSG.jl
@@ -288,7 +288,7 @@ end
 Calculates the intersection of `r` with CSG object, `obj`.
 
 Returns an [`EmptyInterval`](@ref) if there is no intersection, an [`Interval`](@ref) if there is one or two
-interesections and a [`DisjointUnion`](@ref) if there are more than two intersections.
+intersections and a [`DisjointUnion`](@ref) if there are more than two intersections.
 
 The ray is intersected with the [`LeafNode`](@ref)s that make up the CSG object and the resulting `Interval`s and
 `DisjointUnion`s are composed with the same boolean operations to give a final result.
@@ -395,7 +395,7 @@ end
 
 ########################################################################################################################
 
-# currrently we assume that no triangles span 2 sides of a shape, i.e. any triangle only crosses one shape boundary and
+# currently we assume that no triangles span 2 sides of a shape, i.e. any triangle only crosses one shape boundary and
 # so splitting is trivial
 function uniontri!(
     csg::CSGTree{T}, tri::Triangle{T}, triangles::Vector{Triangle{T}}, thisforcoplanar::Bool = false
@@ -576,7 +576,7 @@ function splittri2out!(
     end
 end
 
-# visualization functions from CSG objects, most actualy work happens in the above functions
+# visualization functions from CSG objects, most actually work happens in the above functions
 function makemeshi(a::UnionNode{T}, subdivisions::Int = 30)::Vector{Triangle{T}} where {T<:Real}
     # do the two children in parallel
     th1 = Threads.@spawn makemesh(a.leftchild, subdivisions)

--- a/src/Geometry/CSG/Interval.jl
+++ b/src/Geometry/CSG/Interval.jl
@@ -563,7 +563,7 @@ difference(a::DisjointUnion, b::DisjointUnion) = intervalintersection(a, interva
 Apply a Transform to an Interval object
 """
 function Base.:*(transformation::Transform{T}, a::Interval{T}) where {T<:Real}
-    # looks ridiculous but necessary to dissambiguate the elements of the interval
+    # looks ridiculous but necessary to disambiguate the elements of the interval
     u = upper(a)
     l = lower(a)
     if l isa RayOrigin{T}

--- a/src/Geometry/Primitives/AsphericSurface.jl
+++ b/src/Geometry/Primitives/AsphericSurface.jl
@@ -215,7 +215,7 @@ end
 function normal(z::AsphericSurface{T,3}, ρ::T, ϕ::T)::SVector{3,T} where {T<:Real}
     du, dv = partials(z, ρ, ϕ)
     if ρ == zero(T) && norm(dv) == zero(T)
-        # in cases where there is no δϕ at ρ = 0 (i.e. anything which is rotationally symetric)
+        # in cases where there is no δϕ at ρ = 0 (i.e. anything which is rotationally symmetric)
         # then we get some big problems, hardcoding this case solves the problems
         return SVector{3,T}(0, 0, 1)
     end

--- a/src/Geometry/Primitives/Curves/BSpline.jl
+++ b/src/Geometry/Primitives/Curves/BSpline.jl
@@ -39,7 +39,7 @@ spatialdimension(::Spline{T,S,N,M}) where {T,S,N,M} = N
 curveorder(::Spline{T,S,N,M}) where {T,S,N,M} = M
 
 function point(curve::BSplineCurve{P,S,N,M}, u::T)::SVector{N,S} where {T<:Real,P,S,N,M}
-    # returns the raw point type of the curve - for Homogeneous curve types this will be a homogenous point
+    # returns the raw point type of the curve - for Homogeneous curve types this will be a homogeneous point
     span = findspan(curve, u)
     bases = basisfunctions(curve.knotvector, u, M)
     c = zeros(MVector{N,S})

--- a/src/Geometry/Primitives/Curves/Bezier.jl
+++ b/src/Geometry/Primitives/Curves/Bezier.jl
@@ -302,7 +302,7 @@ end
 # end
 
 # "Creates a differentiable function to evaluate a surface point. Zygote has trouble with mutable arrays so this creates a function
-# which unrolls all loops and converts array indexing to variables. Stopped working on this because it became so diffult to make it work."
+# which unrolls all loops and converts array indexing to variables. Stopped working on this because it became so difficult to make it work."
 # function pointinline(surf::BezierSurface{P,S,N,M}, u::T, v::T) where {T<:Real,P,S,N,M}
 #     controlpoints = surf.controlpolygon
 #     qi = zeros(MVector{N * (M + 1),MVector{N,S},1})

--- a/src/Geometry/Primitives/NonCSG/ConvexPolygon.jl
+++ b/src/Geometry/Primitives/NonCSG/ConvexPolygon.jl
@@ -26,7 +26,7 @@ struct ConvexPolygon{N,T<:Real}  <: PlanarShape{T}
     local_frame::Transform{T}
     # local_points::Vector{SVector{2, T}}
     local_points::SMatrix{2,N,T}
-    # for efficency
+    # for efficiency
     _local_frame_inv::Transform{T}                                  # cache the inverse matrix to avoid computing it for every intersection test
     _local_lines::Vector{SVector{3, SVector{2, T}}}                 # defines the edge points + a third point representing the slopes in order to save some calculationsduring ray checking
     _length::Int64                                                  # cache the length of the polygon 

--- a/src/Geometry/Primitives/Plane.jl
+++ b/src/Geometry/Primitives/Plane.jl
@@ -97,7 +97,7 @@ function surfaceintersection(pln::Plane{T,N}, r::AbstractRay{T,N}) where {T<:Rea
 end
 
 function BoundingBox(pln::Plane{T,3}) where {T<:Real}
-    # TODO! this is far from ideal, we should try and do something better for intersection with non-axis-algined planes
+    # TODO! this is far from ideal, we should try and do something better for intersection with non-axis-aligned planes
     # valid for axis aligned planes, otherwise we have to assume an infinite bounding box
     if normal(pln) === SVector{3,T}(0, 0, 1)
         return BoundingBox(typemin(T), typemax(T), typemin(T), typemax(T), typemin(T), pln.pointonplane[3])

--- a/src/Geometry/Primitives/Qtype.jl
+++ b/src/Geometry/Primitives/Qtype.jl
@@ -200,11 +200,11 @@ function dSdx(coeffs::SVector{NP1,T}, m::Int, x::T)::T where {T<:Real,NP1}
     dαₙ₊₁ = zero(T)
     dαₙ = zero(T)
     @inbounds for n in N:-1:0
-        # calcualte deriv
+        # calculate deriv
         Bmn = B(m, n)
         k = (A(m, n) + Bmn * x)
         Cmnp1 = C(m, n + 1)
-        if n < N # derivative calcualted from N-1 to 0, so ignore first iteration
+        if n < N # derivative calculated from N-1 to 0, so ignore first iteration
             # 2 eq B.11
             dαₙ = Bmn * αₙ₊₁ + k * dαₙ₊₁ - Cmnp1 * dαₙ₊₂
             if n > 0
@@ -639,7 +639,7 @@ end
 function normal(z::QTypeSurface{T,D,M,N}, ρ::T, θ::T)::SVector{3,T} where {T<:Real,D,M,N}
     du, dv = partials(z, ρ, θ)
     if ρ == zero(T) && norm(dv) == zero(T)
-        # in cases where there is no δθ at ρ = 0 (i.e. anything which is rotationally symetric)
+        # in cases where there is no δθ at ρ = 0 (i.e. anything which is rotationally symmetric)
         # then we get some big problems, hardcoding this case solves the problems
         return SVector{3,T}(0, 0, 1)
     end

--- a/src/Geometry/Primitives/Zernike.jl
+++ b/src/Geometry/Primitives/Zernike.jl
@@ -216,7 +216,7 @@ end
 function normal(z::ZernikeSurface{T,3,P,Q,M}, ρ::T, ϕ::T)::SVector{3,T} where {T<:Real,P,Q,M}
     du, dv = partials(z, ρ, ϕ)
     if ρ == zero(T) && norm(dv) == zero(T)
-        # in cases where there is no δϕ at ρ = 0 (i.e. anything which is rotationally symetric)
+        # in cases where there is no δϕ at ρ = 0 (i.e. anything which is rotationally symmetric)
         # then we get some big problems, hardcoding this case solves the problems
         return SVector{3,T}(0, 0, 1)
     end

--- a/src/Geometry/Surface.jl
+++ b/src/Geometry/Surface.jl
@@ -47,7 +47,7 @@ If the origin o is on the inside of the plane then the inside interval will be (
 
 It is the programmer's responsibility to return Interval results from surfaceintersection that maintain these properties.
 
-The following must be impemented only if the surface is being used as a detector
+The following must be implemented only if the surface is being used as a detector
 ```julia
 uv(surface::Surface{T}, p::SVector{3,T}) -> SVector{2,T}
 uvtopix(surface::Surface{T}, uv::SVector{2,T}, imsize::Tuple{Int,Int}) -> Tuple{Int,Int}
@@ -165,7 +165,7 @@ export samplesurface
     triangulate(surf::ParametricSurface{S,N}, quads_per_row::Int, extensionu::Bool = false, extensionv::Bool = false, radialu::Bool = false, radialv::Bool = false)
 
 Create an array of triangles representing the parametric surface where vertices are sampled on an even grid in UV space.
-The surface can be extended by 1% in u and v separately, and specifying either u or v as being radial - i.e. detemining the radius on the surface e.g. rho for zernike - will result in that dimension being sampled using sqwrt so that area of triangles is uniform. The extension will also only apply to the maximum in this case.
+The surface can be extended by 1% in u and v separately, and specifying either u or v as being radial - i.e. determining the radius on the surface e.g. rho for zernike - will result in that dimension being sampled using sqwrt so that area of triangles is uniform. The extension will also only apply to the maximum in this case.
 """
 function triangulate(surf::ParametricSurface{T,N}, subdivisons::Int, extensionu::Bool = false, extensionv::Bool = false, radialu::Bool = false, radialv::Bool = false) where {T,N}
     triangles = newintrianglepool!(T)

--- a/src/Geometry/Transform.jl
+++ b/src/Geometry/Transform.jl
@@ -214,7 +214,7 @@ Base.transpose(a::Transform{T}) where{T<:Real} = Transform{T}(a.matrix')
 # END of functions for compatibility with base matrix API
 
 
-# for compatability ith the "old" RigidBodyTransform
+# for compatibility ith the "old" RigidBodyTransform
 """
 identitytransform([S::Type]) -> Transform{S}
 
@@ -240,7 +240,7 @@ end
 """
     Transform(colx::Vec3{T}, coly::Vec3{T},colz::Vec3{T}, colw::Vec3{T}, ::Type{T} = Float64) where {T<:Real}
 
-Costruct a transform from the input columns.     
+Construct a transform from the input columns.     
 """
 function Transform(colx::Vec3{T}, coly::Vec3{T}, colz::Vec3{T}, colw::Vec3{T} = zero(Vec3{T})) where {T<:Real}
     return Transform{T}(vcat(hcat(colx,coly,colz,colw),SMatrix{1,4,T}(zero(T),zero(T),zero(T),one(T)) ))
@@ -250,7 +250,7 @@ end
 """
     Transform(colx::Vec3{T}, coly::Vec3{T},colz::Vec3{T}, colw::Vec3{T}, ::Type{T} = Float64) where {T<:Real}
 
-Costruct a transform from the input columns.     
+Construct a transform from the input columns.     
 """
 function Transform(colx::Vec4{T}, coly::Vec4{T}, colz::Vec4{T}, colw::Vec4{T}) where {T<:Real}
     return Transform{T}(hcat(colx,coly,colz,colw))
@@ -259,7 +259,7 @@ end
 """
     Transform(origin, forward) -> Transform{S}
 
-Returns the [`Transform`](@ref) of type `S` (default `Float64`) representing the local frame with origin and forward direction. the other 2 axes are computed automaticlly.
+Returns the [`Transform`](@ref) of type `S` (default `Float64`) representing the local frame with origin and forward direction. the other 2 axes are computed automatically.
 """
 function Transform(origin::Vec3{T}, forward::Vec3{T} = unitZ3()) where {T<:Real}
     forward = normalize(forward)
@@ -515,7 +515,7 @@ export world2local
 """
     decomposeRTS(tr::Transform{T}) where {T<:Real}
 
-return a touple containing the rotation matrix, the translation vector and the scale vecto represnting the transform.
+return a tuple containing the rotation matrix, the translation vector and the scale vecto represnting the transform.
 """
 function decomposeRTS(tr::Transform{T}) where {T<:Real}
     t = Vec3(tr[1,4], tr[2,4], tr[3,4])

--- a/src/GlassCat/utilities.jl
+++ b/src/GlassCat/utilities.jl
@@ -10,7 +10,7 @@ Transmission values are linearly interpolated from the adjacent values in the da
 
 Absorption is defined as ``\\frac{-\\log(t)}{\\tau}`` where ``t`` is the transmission value and ``\\tau`` is the thickness, both of which are provided in the data table.
 
-If unitless, arguments are interpretted as μm, °C and Atm respectively.
+If unitless, arguments are interpreted as μm, °C and Atm respectively.
 
 # Examples
 ```julia-repl
@@ -87,7 +87,7 @@ end
 Compute the refractive index of `glass` at `wavelength`, optionally at specified `temperature` and `pressure`.
 Result is relative to the refractive index of air at given temperature and pressure.
 
-If unitless, arguments are interpretted as μm, °C and Atm respectively.
+If unitless, arguments are interpreted as μm, °C and Atm respectively.
 
 **This is defined to always equal 1.0 for Air at any temperature and pressure**, use [`absairindex`](@ref) for the absolute refractive index of air at a given temperature and pressure.
 
@@ -109,7 +109,7 @@ function index(glass::Glass, wavelength::Length; temperature::Temperature = TEMP
 end
 
 function index(glass::Glass, λ::T; temperature::T = T(TEMP_REF), pressure::T = T(PRESSURE_REF))::T where {T<:Real}
-    # all calculations for the material must be done at the refernce temperature
+    # all calculations for the material must be done at the reference temperature
     reference_temp = T(glass.temp)
 
     # to work out the wavelength at the reference temperature we need the RIs of air at system temp and at reference temp
@@ -215,7 +215,7 @@ end
 """
     absairindex(wavelength; temperature=20°C, pressure=1Atm)
 
-Compute the absolute refractive index of air at `wavelength`, optionally at specified `temperature` and `pressure`. If unitless, arguments are interpretted as μm, °C and Atm respectively.
+Compute the absolute refractive index of air at `wavelength`, optionally at specified `temperature` and `pressure`. If unitless, arguments are interpreted as μm, °C and Atm respectively.
 
 # Examples
 ```julia-repl

--- a/src/NotebooksUtils/NotebooksUtils.jl
+++ b/src/NotebooksUtils/NotebooksUtils.jl
@@ -20,7 +20,7 @@ mutable struct Defs
     authors::String     # authors
     desc::String        # description of the notebook
     width::Int64
-    html::String        # work area to accumulate html syntaxt in order to save cell space (ouput at the end of a single cell)
+    html::String        # work area to accumulate html syntax in order to save cell space (output at the end of a single cell)
 end
 Defs() = Defs("?Authors?")
 Defs(authors) = Defs(authors, "")
@@ -34,7 +34,7 @@ end
 """
     function run(notebook_filename)
 
-Launch Pluto and allow teh user to open a specific notebook.
+Launch Pluto and allow the user to open a specific notebook.
 """
 function run(notebook_filename)
     run(; path=notebook_filename)
@@ -43,8 +43,8 @@ end
 """
     function run(; port=nothing, path=nothing, sysimage_file=nothing )
 
-Launch Pluto and allow teh user to open a specific notebook.
-Also allow the usage of a sysimage file for faster loading.        
+Launch Pluto and allow the user to open a specific notebook.
+Also allow the usage of a sysimage file for faster loading.
 """
 function run(; port=nothing, path=nothing, sysimage_file=nothing, auto_detect_sysimage = false )
 
@@ -115,7 +115,7 @@ end
 
 Launch Pluto and allow the user to open a specific sample notebook. If a notebook of the same name exists in the current working folder,
 it will be opened in Pluto, otherwise, the original sample notebook will be copied to the current folder and be used.
-This beheviour will prevent users from updating the original sample notebook. 
+This behaviour will prevent users from updating the original sample notebook.
 """
 function run_sample(sample_name::String, edit_original::Bool = false)
     folder, basename = splitdir(sample_name)
@@ -263,7 +263,7 @@ end
 """
     function SetDocsBackend(be::String)
 
-    Sets the backend for documantation images.
+    Sets the backend for documentation images.
 """
 function SetDocsBackend(be::String)
     if (be == "Web")

--- a/src/Optical/Emitters/AngularPower.jl
+++ b/src/Optical/Emitters/AngularPower.jl
@@ -49,7 +49,7 @@ end
 GGaussian power distribution. Ray power is calculated by:
 
 `power = power * exp(-(gaussianu * l^2 + gaussianv * m^2))`
-where l and m are the cos_angles between the two axes respectivly.
+where l and m are the cos_angles between the two axes respectively.
 """
 struct Gaussian{T} <: AbstractAngularPowerDistribution{T}
     gaussianu::T

--- a/src/Optical/Emitters/Directions.jl
+++ b/src/Optical/Emitters/Directions.jl
@@ -190,7 +190,7 @@ function Emitters.generate(d::HexapolarCone{T}, n::Int64) where {T<:Real}
         pind = n - (t - 6 * ringi)
         
         ϕ = (pind / (6 * ringi)) * 2π
-        # elevation calculated as ring fraction multipled by max angle
+        # elevation calculated as ring fraction multiplied by max angle
         θ = acos(clamp(one(T) +  (cos(ρ * θmax) - 1), -one(T), one(T)))
         return normalize(sin(θ) * (cos(ϕ) * uvec + sin(ϕ) * vvec) + cos(θ) * dir)
     end

--- a/src/Optical/Emitters/Sources.jl
+++ b/src/Optical/Emitters/Sources.jl
@@ -46,7 +46,7 @@ transform(::RayListSource) = identitytransform()
 """
     Source{T<:Real, Tr<:Transform{T}, S<:Spectrum.AbstractSpectrum{T}, O<:Origins.AbstractOriginDistribution{T}, D<:Directions.AbstractDirectionDistribution{T}, P<:AngularPower.AbstractAngularPowerDistribution{T}} <: AbstractSource{T}
 
-This data-type represents the basic emitter (Source), which is a combination of a Spectrum, Angular Power Distribution, Origins and Directions distibution and a 3D Transform.
+This data-type represents the basic emitter (Source), which is a combination of a Spectrum, Angular Power Distribution, Origins and Directions distribution and a 3D Transform.
 
 ```julia
 Source(::Type{T} = Float64;

--- a/src/Optical/Fresnel.jl
+++ b/src/Optical/Fresnel.jl
@@ -74,7 +74,7 @@ end
 """
     fresnel(nᵢ::T, nₜ::T, sinθᵢ::T, sinθₜ::T) -> Tuple{T,T}
 
-Returns reflectance and tranmission power coefficients according to the [Fresnel equations](https://en.wikipedia.org/wiki/Fresnel_equations).
+Returns reflectance and transmission power coefficients according to the [Fresnel equations](https://en.wikipedia.org/wiki/Fresnel_equations).
 For geometric ray tracing this coefficient can be used directly to compute intensity on the detector plane. For Huygens phase optics need to take the square root to compute the amplitude.
 The power of the transmitted and refracted rays may not sum to one because of the area correction applied to the transmitted component.
 The intensity per area can increase or decrease depending on the indices of refraction.

--- a/src/Optical/Grating.jl
+++ b/src/Optical/Grating.jl
@@ -206,7 +206,7 @@ function processintersection(opticalinterface::HologramInterface{T}, point::SVec
     else
         nsig = one(T)
     end
-    # get the signal magnitue in the substrate
+    # get the signal magnitude in the substrate
     mag_Ksig = 2π * nₛ / opticalinterface.recordingλ
     # and direction
     if opticalinterface.signalbeamstate === CollimatedBeam
@@ -216,7 +216,7 @@ function processintersection(opticalinterface::HologramInterface{T}, point::SVec
     elseif opticalinterface.signalbeamstate === DivergingBeam
         Ksig_raw = normalize(point - opticalinterface.signalpointordir)
     else
-        throw(ErrorException("Invalide beam state"))
+        throw(ErrorException("Invalid beam state"))
     end
     # refract it for the substrate interface
     sigonside = dot(Ksig_raw, normal) < zero(T)
@@ -233,7 +233,7 @@ function processintersection(opticalinterface::HologramInterface{T}, point::SVec
     else
         nref = one(T)
     end
-    # get the reference magnitue in the substrate
+    # get the reference magnitude in the substrate
     mag_Kref = 2π * nₛ / opticalinterface.recordingλ
     if opticalinterface.referencebeamstate === CollimatedBeam
         Kref_raw = opticalinterface.referencepointordir
@@ -242,7 +242,7 @@ function processintersection(opticalinterface::HologramInterface{T}, point::SVec
     elseif opticalinterface.referencebeamstate === DivergingBeam
         Kref_raw = normalize(point - opticalinterface.referencepointordir)
     else
-        throw(ErrorException("Invalide beam state"))
+        throw(ErrorException("Invalid beam state"))
     end
     # refract it for the substrate interface
     refonside = dot(Kref_raw, normal) < zero(T)

--- a/src/Optical/LensAssembly.jl
+++ b/src/Optical/LensAssembly.jl
@@ -9,7 +9,7 @@ Structure which contains the elements of the optical system, these can be [`CSGT
 
 In order to prevent type ambiguities bespoke structs are created for each possible number of elements e.g. `LensAssembly3`.
 These are parameterized by the types of the elements to prevent ambiguities.
-Basic surface types such as [`Rectangle`](@ref) (which can occur in large numbers) are stored independently in `Vector`s, so type paramters are only needed for CSG objects.
+Basic surface types such as [`Rectangle`](@ref) (which can occur in large numbers) are stored independently in `Vector`s, so type parameters are only needed for CSG objects.
 
 Each struct looks like this:
 ```julia

--- a/src/Optical/Lenses.jl
+++ b/src/Optical/Lenses.jl
@@ -134,7 +134,7 @@ function FresnelLens(insidematerial::G, frontvertex::T, radius::T, thickness::T,
         if radius == zero(T) || isinf(radius)
             @error "Invalid radius"
         end
-        # spherical lens which makes things much easier, we can just caluclate groove positions directly
+        # spherical lens which makes things much easier, we can just calculate groove positions directly
         n = 1
         if radius > zero(T)
             sphere = Sphere(radius, interface = interface)

--- a/src/RepeatingStructures/Multilens/Analysis.jl
+++ b/src/RepeatingStructures/Multilens/Analysis.jl
@@ -125,7 +125,7 @@ function ρatairyvalue(airyvalue)
 end
 export ρatairyvalue
 
-""" Spacing between lenslets which guarantess that for any pixel visible in all lenslets every point on the eyebox plane is covered. This is closest packing of circles."""
+""" Spacing between lenslets which guarantees that for any pixel visible in all lenslets every point on the eyebox plane is covered. This is closest packing of circles."""
 closestpackingdistance(pupildiameter::Unitful.Length) = pupildiameter * cosd(30)
 export closestpackingdistance
 

--- a/src/RepeatingStructures/Multilens/Example.jl
+++ b/src/RepeatingStructures/Multilens/Example.jl
@@ -339,7 +339,7 @@ function center_data()
 end
 export center_data
 
-"""verify that paraxial lens properly transorms rays into local coordinate frame to compute intersections with convex poly shape"""
+"""verify that paraxial lens properly transforms rays into local coordinate frame to compute intersections with convex poly shape"""
 function test_paraxial_convex_poly()
     lens,eyebox_center,display_center = center_data()
 

--- a/src/Vis/Emitters.jl
+++ b/src/Vis/Emitters.jl
@@ -32,7 +32,7 @@ function maybe_draw_debug_info(scene::Makie.LScene, o::Origins.AbstractOriginDis
     pos = origin(transform)
 
     if (debug)
-        # this is a stupid hack to force makie to render in 3d - for some scenes, makie decide with no apperent reason to show in 2d instead of 3d
+        # this is a stupid hack to force makie to render in 3d - for some scenes, makie decide with no apparent reason to show in 2d instead of 3d
         Makie.scatter!(scene, [pos[1], pos[1]+0.1], [pos[2], pos[2]+0.1], [pos[3], pos[3]+0.1], color=:red, markersize=0)
 
         # draw the origin and normal of the surface

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -65,7 +65,7 @@ global current_mode = nothing           # modes:    nothing, :default  -> Origin
                                         #           :pluto             -> support pluto notebooks 
                                         #           :docs              -> support documenter figures 
 
-# added the following 2 functions to allow us to hack the drawing mechanisim while in a pluto notebook
+# added the following 2 functions to allow us to hack the drawing mechanism while in a pluto notebook
 set_current_main_scene(scene) = (global current_main_scene = scene)
 set_current_3d_scene(lscene) = (global current_3d_scene = lscene)
 
@@ -160,8 +160,8 @@ function make2dy(scene::Makie.LScene = current_3d_scene)
     s.transformation.rotation[] = scene_transform
     # hide x ticks
 
-    # there is a bug in Makie 0.14.2 which cause an exception setting the X showticks to false. 
-    # we work wround it by making sure the labels we want to turn off are ortogonal to the view direction 
+    # there is a bug in Makie 0.14.2 which causes an exception setting the X showticks to false.
+    # we work around it by making sure the labels we want to turn off are orthogonal to the view direction
     # s[Makie.OldAxis].attributes.showticks[] = (false, true, true)
     s[Makie.OldAxis].attributes.showticks[] = (true, true, true)
 
@@ -193,8 +193,8 @@ function make2dx(scene::Makie.LScene = current_3d_scene)
     s.transformation.rotation[] = scene_transform
     # hide y ticks
 
-    # there is a bug in Makie 0.14.2 which cause an exception setting the X showticks to false. 
-    # we work wround it by making sure the labels we want to turn off are ortogonal to the view direction 
+    # there is a bug in Makie 0.14.2 which causes an exception setting the X showticks to false.
+    # we work around it by making sure the labels we want to turn off are orthogonal to the view direction
     s[Makie.OldAxis].attributes.showticks[] = (true, false, true)
 
     # set tick and axis label rotation and position
@@ -850,7 +850,7 @@ end
 Calculates and displays the surface sag of an arbitrary [`Surface`](@ref) or [`CSGTree`](@ref).
 
 Rays are shot in a grid of size defined by `resolution` across a arectangular area defined by `halfsizes`.
-This rectangle is centred at `postion` with normal along `direction` and rotation defined by `rotationvec`.
+This rectangle is centered at `position` with normal along `direction` and rotation defined by `rotationvec`.
 `offset` is subtracted from the sag measurements to provide values relative to the appropriate zero level.
 """
 function surfacesag(object::Union{CSGTree{T},Surface{T}}, resolution::Tuple{Int,Int}, halfsizes::Tuple{T,T}; offset::T = T(10), position::SVector{3,T} = SVector{3,T}(0.0, 0.0, 10.0), direction::SVector{3,T} = SVector{3,T}(0.0, 0.0, -1.0), rotationvec::SVector{3,T} = SVector{3,T}(0.0, 1.0, 0.0)) where {T<:Real}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ const SEED = 12312487
 const ALL_TESTS = isempty(ARGS) || "all" in ARGS || "All" in ARGS || "ALL" in ARGS
 const TESTSET_DIR = "testsets"
 
-"""Evalute all functions not requiring arguments in a given module and test they don't throw anything"""
+"""Evaluate all functions not requiring arguments in a given module and test they don't throw anything"""
 macro test_all_no_arg_functions(m)
     quote
         for n in names($m, all = true)

--- a/test/testsets/Intersection.jl
+++ b/test/testsets/Intersection.jl
@@ -546,7 +546,7 @@
         r = Ray([0.9, 1.0, 1.9], [0.0, -1.0, 0.0])
         @test surfaceintersection(annulus, r) isa EmptyInterval
 
-        # polygon stop intesection
+        # polygon stop intersection
         polygon_stop_frame = Transform()
         polygon_stop_poly = ConvexPolygon(polygon_stop_frame, [SVector(0.0, 0.0), SVector(1.0, 0.0), SVector(0.5, 0.5)], opaqueinterface(Float64))
         polygon_stop = InfiniteStopConvexPoly(polygon_stop_poly)        
@@ -596,7 +596,7 @@
         end
 
         if missedintersections > 0
-            @warn "$missedintersections out of total $(length(samples)) bezier suface intersections were missed"
+            @warn "$missedintersections out of total $(length(samples)) bezier surface intersections were missed"
         end
 
         # miss from outside
@@ -715,7 +715,7 @@
         end
 
         if missedintersections > 0
-            @warn "$missedintersections out of total $(length(samples)) zernike suface intersections were missed"
+            @warn "$missedintersections out of total $(length(samples)) zernike surface intersections were missed"
         end
 
         # hit from inside
@@ -831,7 +831,7 @@
         end
 
         if missedintersections > 0
-            @warn "$missedintersections out of total $(length(samples)) qtype suface intersections were missed"
+            @warn "$missedintersections out of total $(length(samples)) qtype surface intersections were missed"
         end
 
         # hit from inside
@@ -1137,7 +1137,7 @@
         end
 
         if missedintersections > 0
-            @warn "$missedintersections out of total $(length(samples)) chebychev suface intersections were missed"
+            @warn "$missedintersections out of total $(length(samples)) Chebyshev surface intersections were missed"
         end
 
         z1 = TestData.chebyshevsurface1()
@@ -1260,7 +1260,7 @@
         end
 
         if missedintersections > 0
-            @warn "$missedintersections out of total $(length(samples1) + length(samples2)) gridsag suface intersections were missed"
+            @warn "$missedintersections out of total $(length(samples1) + length(samples2)) gridsag surface intersections were missed"
         end
 
         # hit from inside

--- a/test/testsets/Repeat.jl
+++ b/test/testsets/Repeat.jl
@@ -21,7 +21,7 @@
     @test isapprox(Repeat.Multilens.spherepoint(1,0.0,π/4), [sqrt(2)/2,0.0,sqrt(2)/2])
 
 
-    """ Create a LatticeCluser with three elements at (0,0),(-1,0),(-1,1) coordinates in the HexBasis1 lattice"""
+    """ Create a LatticeCluster with three elements at (0,0),(-1,0),(-1,1) coordinates in the HexBasis1 lattice"""
     function hex3cluster()
         clusterelts = SVector((0,0),(-1,0),(-1,1))
         eltlattice = Repeat.HexBasis1()


### PR DESCRIPTION
Just a small PR to fix some typos I noticed while browsing the source and documentation. I am not seeking credit for this, it is a very minor fix.