### PR TITLE
Update GridSag.jl

### DIFF
--- a/src/Geometry/Primitives/GridSag.jl
+++ b/src/Geometry/Primitives/GridSag.jl
@@ -39,8 +39,7 @@ struct GridSagSurface{T,N,S<:Union{ZernikeSurface{T,N},ChebyshevSurface{T,N}},Nu
 
     function GridSagSurface(basesurface::S, sag_grid::AbstractArray{T,2}; interpolation::GridSagInterpolation = GridSagBicubic, decenteruv::Tuple{T,T} = (zero(T), zero(T))) where {T<:Real,N,S<:Union{ZernikeSurface{T,N},ChebyshevSurface{T,N}}}
         grid = []
-        Nv, Nu, d = size(sag_grid)
-        @assert d == 4
+        Nv, Nu = size(sag_grid)
         for r in 1:Nu
             row = []
             for c in 1:Nv


### PR DESCRIPTION
The function "GridSagSurface(... AbstractArray{T,2}...)" tries to assert that the third dimension of the array has length 4, althoug the input only has two dimensions. The third dimension should be filled with all zeroes in line 46. Probably copy-paste issue from the 3D-array functions.